### PR TITLE
Fix hidden homepage posts

### DIFF
--- a/_sass/_animations.scss
+++ b/_sass/_animations.scss
@@ -1,5 +1,6 @@
 .flex-grid article {
-  opacity: 0;
+  // Post content must remain visible when animation JavaScript is unavailable.
+  opacity: 1;
 }
 
 .flex-grid article.shown {

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -108,6 +108,7 @@
   .box-body {
     img {
       width: 100%;
+      height: auto;
       aspect-ratio: 16 / 9;
       object-fit: cover;
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- keep homepage post cards visible when animation JavaScript is unavailable
- restore responsive thumbnail heights while preserving the 16:9 card layout

## Root cause
The stylesheet set every `.flex-grid article` to `opacity: 0`, but the replacement JavaScript no longer added the `shown` or `animate` class.

## Validation
- verified all 13 homepage post cards render with `opacity: 1`
- verified scrolling leaves cards visible
- verified thumbnails render at the expected 16:9 dimensions