### PR TITLE
Fix GitHub Pages Sass build

### DIFF
--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -8,7 +8,7 @@
   background: #090a0c;
   color: #fff;
 
-  @include media(">=sm") { min-height: min(880px, 94vh); }
+  @include media(">=sm") { min-height: 94vh; }
 
   .hero-art, .hero-shade { position: absolute; inset: 0; width: 100%; height: 100%; }
   .hero-art { z-index: -2; object-fit: cover; object-position: 69% center; }
@@ -17,7 +17,8 @@
     background: linear-gradient(90deg, rgba(5, 6, 8, 0.98) 0%, rgba(5, 6, 8, 0.88) 42%, rgba(5, 6, 8, 0.08) 78%), linear-gradient(0deg, #141414 0%, transparent 24%);
   }
   .content {
-    width: min(100%, rem(1180px));
+    width: 100%;
+    max-width: rem(1180px);
     margin: 0 auto;
     padding: rem(125px) rem(24px) rem(70px);
     @include media(">=sm") { padding: rem(145px) rem(54px) rem(80px); }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -375,7 +375,8 @@
   ol {
     position: absolute;
     right: 0;
-    width: min(rem(390px), 80vw);
+    width: 80vw;
+    max-width: rem(390px);
     max-height: 55vh;
     overflow-y: auto;
     margin: rem(8px) 0 0;
@@ -807,4 +808,3 @@
   border: rem(1px) solid #ccc;
   text-align: left;
 }
-

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -15,7 +15,8 @@
 .search-form {
   position: relative;
   top: 0;
-  width: min(100%, rem(900px));
+  width: 100%;
+  max-width: rem(900px);
   margin: 0 auto;
   transform: translateX(-200px);
   transition: all 200ms 100ms cubic-bezier(0, 0.6, 0.4, 1);


### PR DESCRIPTION
## Fix

GitHub Pages deploys this site with Jekyll 3.10 and legacy Sass 3.7. The CSS `min()` expressions added in PR #3 were interpreted as Sass functions, causing the deployment error `Incompatible units: 'rem' and '%'`.

This replaces all three mixed-unit `min()` expressions with equivalent `width`/`max-width` declarations and a viewport-height hero rule that legacy Sass can compile.

## Validation

- Reproduced the reported failure with `ghcr.io/actions/jekyll-build-pages:v1.0.13`
- Rebuilt successfully using that exact image (`github-pages` v232, Jekyll 3.10.0, Sass 3.7)
- Confirmed no remaining CSS `min()` expressions
- `git diff --check` passes