### PR TITLE
Fix menu drawer interaction

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -40,7 +40,7 @@
 </footer>
 
 <!-- Include the website scripts -->
-<script src="{{ '/assets/js/scripts.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/scripts.js' | relative_url }}?v={{ site.time | date: '%s' }}"></script>
 
 <!-- Include extra scripts -->
 {% include extra-js.html %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,8 @@
+<input id="menu" class="menu-state visually-hidden" type="checkbox" tabindex="-1" aria-hidden="true">
 <header class="bar-header">
-    <button id="menu" type="button" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
+    <label class="menu-toggle" for="menu" role="button" tabindex="0" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
         <svg id="open" class="icon-menu"><use xlink:href="#icon-menu"></use></svg>
-    </button>
+    </label>
     <div class="logo">
         <a href="{{ site.baseurl }}/">
             {% if site.use_logo %}
@@ -24,7 +25,7 @@
     {% endcomment %}
 </header>
 
-<div id="mask" class="overlay"></div>
+<div id="mask" class="overlay" aria-hidden="true"></div>
 
 {% include menu.html %}
 {% include search.html %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,4 +1,7 @@
 <aside class="sidebar" id="sidebar">
+    <label class="menu-close" for="menu" role="button" tabindex="0" aria-label="Close menu">
+      <svg aria-hidden="true"><use xlink:href="#icon-close"></use></svg>
+    </label>
     <nav id="navigation">
       <h2>Menu</h2>
       {% include links.html %}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -82,8 +82,11 @@ body {
     min-height: rem(44px);
   }
 
-  #menu {
+  .menu-toggle {
     float: left;
+    display: block;
+    min-width: rem(44px);
+    min-height: rem(44px);
   }
 
   .dosearch {

--- a/_sass/_menu.scss
+++ b/_sass/_menu.scss
@@ -4,49 +4,71 @@
   box-sizing: border-box;
 }
 
-body.has-push-menu,
-body.has-push-menu aside,
-body.has-push-menu .progress-bar {
-  transition: all 0.3s ease;
-}
-
 body.has-push-menu {
   overflow-x: hidden;
-  position: relative;
-  left: 0;
 
-  &.push-menu-to-right {
-    left: rem(240px);
+  &.menu-open { overflow: hidden; }
+}
 
-    .progress-bar {
-      left: rem(240px);
-    }
+.menu-state:checked ~ aside.sidebar {
+  transform: translateX(0);
+  visibility: visible;
+  transition-delay: 0s;
+}
 
-    .bar-header {
-      left: rem(240px);
-    }
-  }
+.menu-state:checked ~ .overlay {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.menu-state:focus-visible ~ .bar-header .menu-toggle {
+  outline: 3px solid $themeColor;
+  outline-offset: 3px;
 }
 
 aside.sidebar {
   position: fixed;
   width: rem(240px);
-  height: 100%;
+  height: 100vh;
   top: 0;
-  left: rem(-240px);
+  left: 0;
+  overflow-y: auto;
+  transform: translateX(-100%);
   background-color: $accentDark;
   z-index: 20;
+  visibility: hidden;
+  transition: transform 0.3s ease, visibility 0s linear 0.3s;
 
   @include media(">=sm") {
     padding: rem(10px) 0 0;
   }
 
   &.open {
-    left: 0;
+    transform: translateX(0);
+    visibility: visible;
+    transition-delay: 0s;
+  }
+
+  .menu-close {
+    position: absolute;
+    top: rem(8px);
+    right: rem(8px);
+    display: grid;
+    width: rem(44px);
+    height: rem(44px);
+    place-items: center;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: $primaryDark;
+    cursor: pointer;
+
+    svg { width: rem(20px); height: rem(20px); fill: currentColor; }
+    &:hover { background: rgba(0, 0, 0, 0.08); }
   }
 
   h2 {
-    margin: 0 rem(20px) 0;
+    margin: 0 rem(60px) 0 rem(20px);
     @include mainFont(400);
     font-size: rem(18px);
     color: $primaryDark;

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -3,8 +3,10 @@
 
   var body = document.body;
   var menuButton = document.getElementById("menu");
+  var menuToggle = document.querySelector(".menu-toggle");
   var sidebar = document.getElementById("sidebar");
   var mask = document.getElementById("mask");
+  var menuClose = sidebar && sidebar.querySelector(".menu-close");
   var searchButton = document.getElementById("search");
   var searchWrapper = document.getElementById("site-search");
   var searchForm = searchWrapper && searchWrapper.querySelector(".search-form");
@@ -16,17 +18,25 @@
   var previousFocus;
 
   function openMenu() {
-    body.classList.add("push-menu-to-right");
+    menuButton.checked = true;
+    body.classList.add("menu-open");
     sidebar.classList.add("open");
     mask.classList.add("show");
-    menuButton.setAttribute("aria-expanded", "true");
+    sidebar.setAttribute("aria-hidden", "false");
+    menuToggle.setAttribute("aria-expanded", "true");
+    menuToggle.setAttribute("aria-label", "Close menu");
+    if (menuClose) menuClose.focus();
   }
 
   function closeMenu() {
-    body.classList.remove("push-menu-to-right");
+    menuButton.checked = false;
+    body.classList.remove("menu-open");
     sidebar.classList.remove("open");
     mask.classList.remove("show");
-    menuButton.setAttribute("aria-expanded", "false");
+    sidebar.setAttribute("aria-hidden", "true");
+    menuToggle.setAttribute("aria-expanded", "false");
+    menuToggle.setAttribute("aria-label", "Open menu");
+    menuToggle.focus();
   }
 
   function loadSearchIndex() {
@@ -87,9 +97,38 @@
     searchStatus.textContent = posts.length ? posts.length + " result" + (posts.length === 1 ? "" : "s") : "No case files found. Try another threat, tool, or topic.";
   }
 
-  if (menuButton && sidebar && mask) {
-    menuButton.addEventListener("click", openMenu);
+  function activateControlOnKeydown(event, action) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    action();
+  }
+
+  if (menuButton && menuToggle && sidebar && mask) {
+    menuButton.addEventListener("change", function () {
+      menuButton.checked ? openMenu() : closeMenu();
+    });
+    menuToggle.addEventListener("click", function (event) {
+      event.preventDefault();
+      menuButton.checked ? closeMenu() : openMenu();
+    });
+    menuToggle.addEventListener("keydown", function (event) {
+      activateControlOnKeydown(event, function () {
+        menuButton.checked ? closeMenu() : openMenu();
+      });
+    });
+    if (menuClose) {
+      menuClose.addEventListener("click", function (event) {
+        event.preventDefault();
+        closeMenu();
+      });
+      menuClose.addEventListener("keydown", function (event) {
+        activateControlOnKeydown(event, closeMenu);
+      });
+    }
     mask.addEventListener("click", closeMenu);
+    sidebar.querySelectorAll("a").forEach(function (link) {
+      link.addEventListener("click", closeMenu);
+    });
   }
 
   if (searchButton && searchWrapper && searchInput && searchClose && searchResults) {
@@ -122,7 +161,7 @@
     }
     if (event.key !== "Escape") return;
     if (body.classList.contains("search-overlay")) closeSearch();
-    if (body.classList.contains("push-menu-to-right")) closeMenu();
+    if (body.classList.contains("menu-open")) closeMenu();
   });
 
   var filterButtons = document.querySelectorAll("[data-filter]");


### PR DESCRIPTION
## What changed

- replace the fragile page-shifting menu with a fixed, transform-based drawer
- add reliable pointer and keyboard controls with correct accessibility state
- add an explicit close button and support closing via the overlay, Escape, or navigation links
- prevent background scrolling while the drawer is open
- add a native checkbox fallback and cache-bust the site JavaScript so visitors receive the fix immediately

## Verification

- built successfully with the exact `ghcr.io/actions/jekyll-build-pages:v1.0.13` GitHub Pages image
- verified open and close behavior in the browser
- verified the drawer at desktop width and a 390px mobile viewport
- verified JavaScript diff and repository whitespace checks