### PR TITLE
Fix header buttons blocked by hidden search panel

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="{{ '/assets/css/styles.css' | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ '/assets/css/styles.css' | prepend: site.baseurl }}?v={{ site.time | date: '%s' }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}">
 
     <!-- Include extra styles -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,7 @@
-<input id="menu" class="menu-state visually-hidden" type="checkbox" tabindex="-1" aria-hidden="true">
 <header class="bar-header">
-    <label class="menu-toggle" for="menu" role="button" tabindex="0" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
+    <button id="menu" class="menu-toggle" type="button" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
         <svg id="open" class="icon-menu"><use xlink:href="#icon-menu"></use></svg>
-    </label>
+    </button>
     <div class="logo">
         <a href="{{ site.baseurl }}/">
             {% if site.use_logo %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,7 @@
-<aside class="sidebar" id="sidebar">
-    <label class="menu-close" for="menu" role="button" tabindex="0" aria-label="Close menu">
+<aside class="sidebar" id="sidebar" aria-hidden="true">
+    <button class="menu-close" type="button" aria-label="Close menu">
       <svg aria-hidden="true"><use xlink:href="#icon-close"></use></svg>
-    </label>
+    </button>
     <nav id="navigation">
       <h2>Menu</h2>
       {% include links.html %}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -84,9 +84,13 @@ body {
 
   .menu-toggle {
     float: left;
-    display: block;
+    display: flex;
     min-width: rem(44px);
     min-height: rem(44px);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    touch-action: manipulation;
   }
 
   .dosearch {

--- a/_sass/_menu.scss
+++ b/_sass/_menu.scss
@@ -10,22 +10,6 @@ body.has-push-menu {
   &.menu-open { overflow: hidden; }
 }
 
-.menu-state:checked ~ aside.sidebar {
-  transform: translateX(0);
-  visibility: visible;
-  transition-delay: 0s;
-}
-
-.menu-state:checked ~ .overlay {
-  pointer-events: auto;
-  opacity: 1;
-}
-
-.menu-state:focus-visible ~ .bar-header .menu-toggle {
-  outline: 3px solid $themeColor;
-  outline-offset: 3px;
-}
-
 aside.sidebar {
   position: fixed;
   width: rem(240px);
@@ -62,6 +46,7 @@ aside.sidebar {
     background: transparent;
     color: $primaryDark;
     cursor: pointer;
+    touch-action: manipulation;
 
     svg { width: rem(20px); height: rem(20px); fill: currentColor; }
     &:hover { background: rgba(0, 0, 0, 0.08); }

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -5,10 +5,14 @@
   padding-right: 5%;
   padding-left: 5%;
   transform: translateY(-200px);
+  visibility: hidden;
+  pointer-events: none;
   z-index: 19;
 
   &.active {
     transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -3,7 +3,6 @@
 
   var body = document.body;
   var menuButton = document.getElementById("menu");
-  var menuToggle = document.querySelector(".menu-toggle");
   var sidebar = document.getElementById("sidebar");
   var mask = document.getElementById("mask");
   var menuClose = sidebar && sidebar.querySelector(".menu-close");
@@ -18,25 +17,23 @@
   var previousFocus;
 
   function openMenu() {
-    menuButton.checked = true;
     body.classList.add("menu-open");
     sidebar.classList.add("open");
     mask.classList.add("show");
     sidebar.setAttribute("aria-hidden", "false");
-    menuToggle.setAttribute("aria-expanded", "true");
-    menuToggle.setAttribute("aria-label", "Close menu");
+    menuButton.setAttribute("aria-expanded", "true");
+    menuButton.setAttribute("aria-label", "Close menu");
     if (menuClose) menuClose.focus();
   }
 
   function closeMenu() {
-    menuButton.checked = false;
     body.classList.remove("menu-open");
     sidebar.classList.remove("open");
     mask.classList.remove("show");
     sidebar.setAttribute("aria-hidden", "true");
-    menuToggle.setAttribute("aria-expanded", "false");
-    menuToggle.setAttribute("aria-label", "Open menu");
-    menuToggle.focus();
+    menuButton.setAttribute("aria-expanded", "false");
+    menuButton.setAttribute("aria-label", "Open menu");
+    menuButton.focus();
   }
 
   function loadSearchIndex() {
@@ -97,33 +94,10 @@
     searchStatus.textContent = posts.length ? posts.length + " result" + (posts.length === 1 ? "" : "s") : "No case files found. Try another threat, tool, or topic.";
   }
 
-  function activateControlOnKeydown(event, action) {
-    if (event.key !== "Enter" && event.key !== " ") return;
-    event.preventDefault();
-    action();
-  }
-
-  if (menuButton && menuToggle && sidebar && mask) {
-    menuButton.addEventListener("change", function () {
-      menuButton.checked ? openMenu() : closeMenu();
-    });
-    menuToggle.addEventListener("click", function (event) {
-      event.preventDefault();
-      menuButton.checked ? closeMenu() : openMenu();
-    });
-    menuToggle.addEventListener("keydown", function (event) {
-      activateControlOnKeydown(event, function () {
-        menuButton.checked ? closeMenu() : openMenu();
-      });
-    });
+  if (menuButton && sidebar && mask) {
+    menuButton.addEventListener("click", openMenu);
     if (menuClose) {
-      menuClose.addEventListener("click", function (event) {
-        event.preventDefault();
-        closeMenu();
-      });
-      menuClose.addEventListener("keydown", function (event) {
-        activateControlOnKeydown(event, closeMenu);
-      });
+      menuClose.addEventListener("click", closeMenu);
     }
     mask.addEventListener("click", closeMenu);
     sidebar.querySelectorAll("a").forEach(function (link) {


### PR DESCRIPTION
## Root cause

The closed search panel was only moved upward with a transform. It remained interactive at `z-index: 19`, invisibly covering the header and intercepting pointer clicks. That is why clicking the hamburger focused the hidden search field and why the header appeared unresponsive.

## Fix

- disable visibility and pointer events on the search panel while it is closed
- restore interaction only when search is active
- replace the label-based hamburger and drawer close controls with native buttons
- give the complete hamburger hit area an explicit pointer cursor and touch behavior
- simplify menu JavaScript around native button events
- add initial drawer accessibility state
- cache-bust the stylesheet so the corrected interaction CSS is delivered immediately

## Verification

- pointer-clicked the hamburger and confirmed the drawer opens
- pointer-clicked the drawer close button and confirmed it closes
- pointer-clicked search and confirmed the search overlay opens
- repeated the menu pointer test at a 390px mobile viewport
- built successfully using the exact GitHub Pages build image
- JavaScript syntax and repository whitespace checks pass