### PR TITLE
Fix case file filters showing every post

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -93,6 +93,10 @@
   position: relative;
   z-index: 1;
 
+  &[hidden] {
+    display: none;
+  }
+
   @include media(">=sm") {
     margin: 0 rem($itemMargin) rem(30px);
   }


### PR DESCRIPTION
## Root cause

The filter JavaScript correctly added the native `hidden` attribute and updated the visible count, but the later `.box-item { display: inline-block; }` rule overrode `[hidden] { display: none; }` in the CSS cascade. The controls appeared to do nothing because every card remained rendered.

## Fix

Add an explicit `.box-item[hidden] { display: none; }` rule next to the card styling so filtered cards are actually removed from the layout.

## Verification

Pointer-tested every filter against the expected visible card count:

- All: 14
- blog: 1
- cybersecurity: 7
- email-security: 1
- inspiration: 1
- personal-growth: 1
- ransomware: 1
- technology: 2

Also verified Technology at a 390px mobile viewport and built successfully with the exact GitHub Pages image.