### PR TITLE
Rebuild resume around security operations experience

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary

--- a/_data/resume.json
+++ b/_data/resume.json
@@ -1,0 +1,63 @@
+{
+  "name": "Harsimran Sidhu",
+  "headline": "Security Operations | Incident Response | Threat Intelligence",
+  "email": "harsimransidhu770@gmail.com",
+  "website": "https://harsim.ca",
+  "linkedin": "https://www.linkedin.com/in/harsimransidhu",
+  "github": "https://github.com/PKHarsimran",
+  "summary": "Security operations analyst with 4+ years of experience across SOC and IT infrastructure. Investigates endpoint, identity, web, email, and network threats; builds detection logic and automation; and turns technical evidence into clear response decisions. Publishes practical SOC playbooks and threat research grounded in real investigation workflows.",
+  "experience": [
+    {
+      "role": "Security Operations Center Analyst",
+      "company": "Columba System Inc",
+      "location": "Remote",
+      "dates": "Nov 2022 - Present",
+      "bullets": [
+        "Investigate endpoint, web, identity, and email-security alerts to validate threats, scope impact, and determine the appropriate response.",
+        "Build and tune Splunk rules and alerts that support threat detection, triage, and repeatable investigation workflows.",
+        "Correlate Cortex XDR, WAF, authentication, URL, and email-header evidence to separate malicious activity from false positives.",
+        "Manage Jira cases from initial triage through documentation and escalation, preserving clear evidence and decision context for IT teams.",
+        "Automate compliance checks and URL-verification tasks with custom scripts to reduce repetitive analyst work."
+      ]
+    },
+    {
+      "role": "Cyber Security Analyst",
+      "company": "SecureOps",
+      "location": "Remote",
+      "dates": "Oct 2021 - Nov 2022",
+      "bullets": [
+        "Investigated and escalated incidents across Microsoft 365 Defender, Splunk, and Microsoft Sentinel within defined service agreements.",
+        "Wrote Kusto Query Language queries to filter security telemetry, validate alert context, and support incident scoping.",
+        "Analyzed network traffic with Wireshark and used an AWS sandbox to examine suspicious activity safely.",
+        "Produced clear investigation updates and coordinated response decisions with distributed technical teams."
+      ]
+    },
+    {
+      "role": "Information Technology Specialist",
+      "company": "Telecom Metrics Inc",
+      "location": "Kingston, Ontario",
+      "dates": "Jan 2021 - Aug 2021",
+      "bullets": [
+        "Led security and infrastructure projects supporting server maintenance, reliability, and operational continuity.",
+        "Implemented high-availability solutions and Python automation for recurring operational tasks.",
+        "Delivered remote troubleshooting and technical support across infrastructure and end-user systems."
+      ]
+    }
+  ],
+  "skills": [
+    {"group": "Security Operations", "items": "Alert triage, incident response, threat hunting, endpoint security, WAF analysis, email security, IOC enrichment, log correlation"},
+    {"group": "Detection and Analysis", "items": "Detection engineering, Splunk rules, KQL, packet analysis, MITRE ATT&CK mapping, technical documentation"},
+    {"group": "Platforms", "items": "Cortex XDR, Splunk, Microsoft 365 Defender, Microsoft Sentinel, AWS Sandbox, Jira, Wireshark"},
+    {"group": "Automation and Engineering", "items": "Python, Bash/Shell, Git, GitHub, Docker, Azure, CI/CD"}
+  ],
+  "selected_work": [
+    {"title": "Web and Identity Incident Response", "description": "Published hands-on playbooks for WordPress compromise and WAF login attacks, covering triage, evidence preservation, log analysis, scoping, containment, and hardening.", "url": "/wordpress-defacement-investigation/"},
+    {"title": "Threat Research", "description": "Analyzed Qilin ransomware, the XZ supply-chain backdoor, and Cortex XDR abuse patterns with attack timelines and defensive recommendations.", "url": "/qilin-ransomware/"},
+    {"title": "Security Engineering and Automation", "description": "Built Python website monitoring, Docker-based network protection, and GitHub/Azure CI/CD projects documented for other practitioners.", "url": "/UniversalWebTracker/"}
+  ],
+  "education": [
+    {"credential": "Cyber Security", "school": "University of Toronto Continuing Education", "location": "Toronto, ON", "dates": "Jan 2020 - Aug 2020"},
+    {"credential": "Bachelor of Engineering in Technology", "school": "Cape Breton University", "location": "Sydney, NS", "dates": "Sept 2017 - Apr 2019"},
+    {"credential": "Electromechanical Engineering - Advanced Diploma", "school": "Humber College", "location": "Toronto, ON", "dates": "Sept 2013 - Apr 2016"}
+  ]
+}

--- a/_sass/_resume.scss
+++ b/_sass/_resume.scss
@@ -1,0 +1,98 @@
+.resume-page {
+  --resume-panel: #1c1c1c;
+  --resume-border: rgba(255, 255, 255, 0.12);
+  max-width: rem(1180px);
+  margin: 0 auto;
+  color: rgba(255, 255, 255, 0.78);
+
+  a { color: inherit; }
+
+  .resume-hero {
+    display: grid;
+    gap: rem(28px);
+    align-items: center;
+    margin-bottom: rem(54px);
+    border: 1px solid var(--resume-border);
+    border-radius: rem(18px);
+    padding: clamp(1.4rem, 5vw, 3.5rem);
+    background: radial-gradient(circle at 100% 0, rgba(239, 63, 74, 0.2), transparent 35%), linear-gradient(135deg, #1c1c1c, #101010);
+    @include media(">=sm") { grid-template-columns: rem(180px) 1fr; }
+  }
+
+  .resume-photo {
+    width: rem(150px);
+    height: rem(150px);
+    border: 3px solid $themeColor;
+    border-radius: 50%;
+    object-fit: cover;
+    @include media(">=sm") { width: rem(180px); height: rem(180px); }
+  }
+
+  .resume-eyebrow, .resume-section-number { margin: 0 0 rem(8px); color: #ef596b; font-size: rem(12px); font-weight: 700; letter-spacing: 0.16em; }
+  h1 { margin: 0; color: #fff; font-size: clamp(2.7rem, 7vw, 5.2rem); line-height: 0.92; }
+  .resume-headline { margin: rem(14px) 0 rem(12px); color: #fff; font-weight: 700; letter-spacing: 0.04em; }
+  .resume-summary { max-width: rem(760px); margin: 0; color: rgba(255, 255, 255, 0.74); font-size: rem(18px); line-height: 1.55; }
+  .resume-actions { display: flex; flex-wrap: wrap; gap: rem(10px); margin-top: rem(24px); }
+  .resume-download { margin: 0; }
+  .resume-secondary { border-color: var(--resume-border); background: transparent; }
+
+  .resume-contact {
+    display: flex;
+    flex-wrap: wrap;
+    gap: rem(8px) rem(18px);
+    margin: rem(22px) 0 0;
+    padding: 0;
+    list-style: none;
+    font-size: rem(14px);
+    li { margin: 0; }
+    a { color: rgba(255, 255, 255, 0.65); text-decoration-color: rgba(255, 255, 255, 0.24); }
+  }
+
+  .resume-layout { display: grid; gap: rem(52px); border-radius: rem(18px); padding: clamp(1.4rem, 4vw, 3rem); background: #141414; @include media(">=56rem") { grid-template-columns: minmax(0, 2fr) minmax(rem(270px), 0.8fr); } }
+  .resume-section { margin-bottom: rem(58px); }
+  .resume-section > h2 { margin: 0 0 rem(25px); color: #fff; font-size: clamp(1.9rem, 4vw, 2.7rem); }
+
+  .resume-role {
+    margin-bottom: rem(18px);
+    border: 1px solid var(--resume-border);
+    border-left: 3px solid $themeColor;
+    border-radius: 0 rem(12px) rem(12px) 0;
+    padding: rem(22px);
+    background: var(--resume-panel);
+    h3 { margin: 0; color: #fff; font-size: rem(21px); }
+    ul { margin: rem(17px) 0 0; padding-left: rem(20px); }
+    li { margin-bottom: rem(9px); color: rgba(255, 255, 255, 0.76); line-height: 1.5; }
+  }
+
+  .resume-role-heading {
+    display: flex;
+    flex-direction: column;
+    gap: rem(7px);
+    @include media(">=sm") { flex-direction: row; justify-content: space-between; }
+    p { margin: rem(3px) 0 0; color: rgba(255, 255, 255, 0.58); }
+    time { flex: 0 0 auto; color: #ef596b; font-size: rem(14px); font-weight: 700; }
+  }
+
+  .resume-work-grid { display: grid; gap: rem(14px); @include media(">=sm") { grid-template-columns: repeat(3, 1fr); } }
+  .resume-work-card {
+    display: flex;
+    min-height: rem(245px);
+    flex-direction: column;
+    border: 1px solid var(--resume-border);
+    border-radius: rem(12px);
+    padding: rem(20px);
+    background: var(--resume-panel);
+    h3 { margin: 0 0 rem(12px); font-size: rem(19px); line-height: 1.25; }
+    h3 a { color: #fff; text-decoration: none; }
+    p { margin: 0; color: rgba(255, 255, 255, 0.7); line-height: 1.5; }
+    .resume-work-link { margin-top: auto; padding-top: rem(18px); color: #ef596b; font-weight: 700; text-decoration: none; }
+  }
+
+  .resume-sidebar .resume-section { border-top: 1px solid var(--resume-border); padding-top: rem(20px); }
+  .resume-skill-group { margin-bottom: rem(24px); h3 { margin: 0 0 rem(6px); color: #fff; font-size: rem(17px); } p { margin: 0; color: rgba(255, 255, 255, 0.7); line-height: 1.55; } }
+  .resume-education { margin-bottom: rem(24px); h3 { margin: 0 0 rem(4px); color: #fff; font-size: rem(17px); line-height: 1.3; } p { margin: 0 0 rem(2px); color: rgba(255, 255, 255, 0.62); line-height: 1.45; } p:last-child { color: #ef596b; font-size: rem(13px); } }
+}
+
+@media print {
+  .resume-page .resume-actions, .resume-page .resume-photo { display: none; }
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -19,6 +19,7 @@
 @import "highlight";
 @import "form";
 @import "author";
+@import "resume";
 @import "staff";
 @import "modal";
 @import "footer";

--- a/assets/files/Harsimran-Sidhu-Resume.pdf
+++ b/assets/files/Harsimran-Sidhu-Resume.pdf
@@ -2,7 +2,7 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 4 0 R
+/F1 2 0 R /F2 3 0 R /F3 8 0 R
 >>
 endobj
 2 0 obj
@@ -17,64 +17,96 @@ endobj
 endobj
 4 0 obj
 <<
-/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+/A <<
+/S /URI /Type /Action /URI (mailto:harsimransidhu770@gmail.com)
+>> /Border [ 0 0 0 ] /Rect [ 40.56 708.44 150.3372 717.8 ] /Subtype /Link /Type /Annot
 >>
 endobj
 5 0 obj
 <<
-/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/A <<
+/S /URI /Type /Action /URI (https://harsim.ca)
+>> /Border [ 0 0 0 ] /Rect [ 156.702 708.44 190.5072 717.8 ] /Subtype /Link /Type /Annot
 >>
 endobj
 6 0 obj
 <<
-/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+/A <<
+/S /URI /Type /Action /URI (https://www.linkedin.com/in/harsimransidhu)
+>> /Border [ 0 0 0 ] /Rect [ 196.872 708.44 303.9348 717.8 ] /Subtype /Link /Type /Annot
 >>
 endobj
 7 0 obj
 <<
-/Author (Harsimran Sidhu) /CreationDate (D:20260831194409+05'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260831194409+05'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (Security Operations and Threat Intelligence Analyst) /Title (Harsimran Sidhu - Resume) /Trapped /False
+/A <<
+/S /URI /Type /Action /URI (https://github.com/PKHarsimran)
+>> /Border [ 0 0 0 ] /Rect [ 310.2996 708.44 396.9888 717.8 ] /Subtype /Link /Type /Annot
 >>
 endobj
 8 0 obj
 <<
-/Count 1 /Kids [ 5 0 R ] /Type /Pages
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
 >>
 endobj
 9 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2462
+/Annots [ 4 0 R 5 0 R 6 0 R 7 0 R ] /Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/PageMode /UseNone /Pages 12 0 R /Type /Catalog
+>>
+endobj
+11 0 obj
+<<
+/Author (Harsimran Sidhu) /CreationDate (D:20260901094453+05'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260901094453+05'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Security Operations, Incident Response, and Threat Intelligence) /Title (Harsimran Sidhu - Resume) /Trapped /False
+>>
+endobj
+12 0 obj
+<<
+/Count 1 /Kids [ 9 0 R ] /Type /Pages
+>>
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3295
 >>
 stream
-Gau0D>BALh(4Q"]3)<c&'TmM=AG0^l-8?0C4%?Bs<99r.2:,i)XjP**;Y/rCl]sd[0e:n.nqE"5qcpo)SC87App'I@59d]4kjlDUQ;-4fXIdfaDakE/ii``"34KmZ/i?s0pSpaJnflZ>#MA)ID+Zf?I_@F/[Am#W3P7,<+W6U-\9<A.gi\C,44&=*gTZ$o?*7@I@l;j2YY4pRm2pLSQ=UJJp/Pk>7UPCCXHYU_^"IA)6[KSj^/B_p]iA4llPY<rfrj9BaG[!<4*mDm5<Y%pBKj,?I3Q6JRSUq!O&PKX\pp)0NkFWTh>A)[rZpr6-)PZa^LnJY!+sgF4cDQuaD*:+$tjJ0RnC2+Rg'kk8'9*RrRR'?P-#5/HuG4N9h%BUF6AjcR>=`Vdp*$V@Ro]&Em=Sam`sdOnmb(RUCL9jL8ADSLPIp/pk\o<hX0?6jO*VFS'5Kn&!OWqKLU0\fcP:=76+o3539.]<Jo(De?;i;6FhNlVTrr:Q:uSCFj9q;,:5apQUlD(8#L\/BBKq*\^U%NbIUNg00BfN3q?1eQb*l72D7M5.\?=aLQC1$[eZg[3'(cTX3u47CW"S9Q:?+3cM\q%q3kj2;jIe/B>e6pY-XY(K_p@Tik(#5,\$]J,2dGNlt$J=nh0Gl8>O%&=`mK+^5UoYjX\YtYq-FPil$?KSo\7ehUpH=nP[;qV`<NU:\cPP3R;Y,$f?ArBc-be&3f6>r/e7l91d9FSBjMo6FM?/ng1&b9K1[<=sueA@_F2Q/BWo0hqGdD+-;efrMn>Q1\i&)R&[N3'5>$*'"JJ5I3$Hb_SoFlPs/nZV*D%qi?/J]-AGaiiW+su<lWS1N+H*Zc]$utb9NIqI[;+$,]c`\d%,P1gU(gD7h<Zekh)aMpj[OQPFtB6AgLBcV5"IdWcp)HGQDs$>-:MjA1VaHc8M"h?G.gYIKMcJ/CU-h9u#RJ&s?#m5V1JI]B\bDPe]+<;44jZ!p=^/<PnHt2Ad:n\P/J^8]W+[fm+2GnI)0^a@g'JOJ`(M^1%(\OX./o=RaIBT*LVf2.T?2V1L;pTk<ub,LcLVL]QO/?LnbBi.^?O*p>PF19E.SJ9hqI+.1C`+L8)!nHe.(/*T=j`J2SH29`TdluO%&.WQD@V'R<5<%uC#EW;kog!eu??GVs9fV??Y'@\Zjm%OoC-ASK>R*I^])2`=GF5j4PdYbA]VkjQj"Q`S!Ej/H3r<0&Ejf^/,Gg9^hTsfJ<O0`C>KoXd2@*:-a*_)V^d&(k.g=2kmI?HJ?o%q\->?YFX%<8gjFEMD,GmpV#UpjnI`:T8_;jk`r:<oM.2gbWejf+8TUu<6AGce3,$pHA^4cnaX5kgL/[uqiF2#7^^,6O$k0b;IQAb9P/F1cdaIk+.o,kZK<n2)&]6]D+(Se$,RGQ[Ye<2;dO$_FM8`o:R'#kMipj6,+I?PMiB,0[+W1oo9[Wds3t:j^!6]lVlu^f->:"H*ni8A8j-6rn?c(BOA%ci'Ri6-k@!]OF;5jfLP$PXSh?4uc*ka8Yo"(YT;q6!)mdeiAC="mV/+Gf0$L`3NLJ)Y!<@)VGlV^l6<:Z&]d#YmNjtPGaja#qB9a2W]bA8s0ZTZ@=']oQ\I-"S[bJ-1S=I\bq74!\#48koRQ5K`lJrL3^:<c;CjrDqibEF.Ni11W167a#5B1<;qaR.bjT&jd:a$c1872F%&Itl<u(Sh86-"cZk<O!/ud<ij%bZ%a5%\%!k+!VXbJG*`T6I'\mkrcoEZc=^r.58jB']>tM#351BY\k1L<VD3SJI8h='4fIL'q4c<,?.`3sH)3%MbW[9=MJSi]<Q\q"Kf(nUhdcNO7M'+jnJ"4l1oJ!kJcDKH?12k9WHVdAl3PI^SE,/b^<PI4khjYDgs4.N6I,@dtX]fm29QW4W`m1*hpKD"CrS=K[XIncAUsW7cs7^Ygr_@mp0Wt"tXbu2>Rfb+W[k+Ju_="aGGe<_G\X@+f&m[Z"FR'#%VFnFK.p?WI*DCcH/JRnrQ$CYk`P_39RUrNPI1R\3nTnD%^FA7PlCnmmg4>=UeQZVfidbj@T^[iH>s1HPJuUG4KN'bYpWE(bd(cQ`eRB7?R3>IF.G6eklL)?8\To+ZbK)Sup8KP&md/:IeiI(sI#8)B6Dh#s+A\k4h3*bob.9pYFV5C;'q=J;MWA&K+3hA\ROrhi_r9#2lBQ26jC"l*G4Hgg>YX1U)i@DN+1a?U,^=K8cA$mPMHl/2ND9TkZpK&mc(9'#D"ZEskA,g/4Hugcp8"Q"2&Xo';4BJHH*Zq#=i0Dajlh,k:'H`p3f#e&n)fGuS0r'-Zs4@2,ZSc<D*%BOa5YrP2]W(95SZgJ(K("JBppe4I:&@A1S^tkXc[a$L#<9k9(XGB'OiA>2:[HA2V2FtclQ0AVO2cmN8GD5@[F>.6a"So/rhm<FmA0#g6=Bh#ipd.<IE'ifo$-R1;`r:^ZI%!e+JcaV2P?TVJL&Q~>endstream
+Gau`V?$G!n&q0MXW2Df8?,5Y;fQgVYR@(6h4.mR+pJ"0foN8%L/]eKDo&HXJ>7q!)J.4S]EY<16F][D!^:1*V"5<Oj;#^_mJ85[uIQ"tq_4-!a[qtR%@H_"pG1#U/Q=4oDqfD\oU?02F71>L<Ea1:[/^&ho31Wgf[YnK;Qs:=uGA-)U[;a=U[>gacgRiL]%iC"GH>1:59u1&Nj_]K0)1<M!+(-k8\buq<0Gt?aO%8&Vi:1M@mX(_LLWSGiq\?bncn;`&*62k5G-A@,;ua`HN8!*[d,"89]1kA2/@/n35_MM:CKc`%gRjr>dpHAWl=Uc(RliSLEqo4VQRQ965DBIT(\u(J417$$X_tC\YMJNQD8`?&h]eGHpY3.CEoWaK@9Z*I\H<uL#,?sik[sVJ_0@qb_QS^hSTd.:p-$(L%I`aU+,1;Yi?:;;'MrB(Q8(!0e'fYBkbC@Uec)Mbje@DV-%n=Mp:oc`T1?"K/<q*>BVPJlhq8A7Xm[JU^T`g?oZ.c.Y;TJ;\p;T-76X_\52B5t3T.-r0i#mrdiui!$A0t)U*A(:O^UO.H+!d:0^34T`$tJd+0Es"hU"<frs:31Q@YD(qhd=P('b9G5`.CPal<A>%q4N"O(Zm:1RSJN/m/QOnLI6g55-k!!fOran2P1`%p>F]L(/B;dfqLX[m=eo?=1]'HP>rRZ@uh<QMq$9S4?up+j3tQ(.';/4AbqOGp\j"m%;er\2?<tpFThqp^s`3g(3Si]`eNNH308+$+e5t_18HEE=8B/BuJI(>+.u(2kam3\&tQnnlJa5?;eIpZA]R9on!@kV9%\YKt%M>M3%5MG;>MtR76*eD&nM8WtK]u"m:ZdU<\,'5T6>`&&7$O*$'%+>hdf`eh:_uF=jDtW3%]9r=sgkeS]!<hJ8n?-dl,Q#G&?DB%B/KZZ^kE`?b(uo'Z1pl62B4PQg'%rtSCbB>H-),WQN`(;14:nj0p?feuQ<_@u$$>ZoM1\?W@*dr+5@[j8BA7&jjj[:.qR5XbEglGEa%@7r_K!Rf;]/OdYhKcamK3[J7+P&qGfBHpb;U?NH_2!_MF@g0gTCMKM0VO4'FQBCkc-8Rd<!abh]L\,gW&.M/4A1ula"HT^7R(,I8Gt^.?=XAn=M<+;*H2=SJk\^Q7$\Pm9ILNB9cjIKR'.6A9a"JS,LhV;eI9du;Uj8+/R?a:@O^J8HFD/t,^QKmfeXo=t+SU9@?`.P-hqs!HP!t$frfj[knE"9;JEQpX%3k9F76U.J;kM,)p$aW%+6&usBH4p^ZG`*:ee7Qsi$(\8&<U$dP*m"WR/%>WHQl@Jhm0!tn!`E`r$+huSA?j`q@NENL0%O!@l+X+6:[,(/+WK;64r9O"@G[SJWQT;(!%Xg-h<PCo0UJI:isQi/V?;2%=ZQ0-7#R2`r+rG&9Nm&6dXElc-W\+&ojNP%MgTDU_MkFI)Vgh<b)2@IYsIkkn2u*5)Z=CnjFRJahg/J.bc`oh0#iOH%)iaY1)\'<].q&oqfDkeHW''k'Ek@J%Cec:id&W<3jOe,:,-Ba\#F2Uho):"&e:6%eaRKOYR(LHVDjt(!NrL8k/h&$5V2gWN,t"-":Rk++NAD.:sH"XogV!L6BSfUS*"ZFR+9#`.Tk'<;L)V)6t.Z)M1$EFO9360k,s6:GeC:BD;F/,4KPALD)l59Wm=1O68MXfl&nD#O885GXUXqV;E/Kd.C#+\lSs9FKT.*%7Vdj-'CmTOn4TUfJ(Y?YW@TT@iVMo7/A\b/Bq)=*/PQF]GG./SuST:rpp7jr*h.i&fU,;YH!^A:QoYC9)TWc<l[8R2U:dLP8(s9@3I1k'h"XHWeD\d![/i_[OTnd[o"')OCJsFV`ES>DT#;t+hQq*VJ!O,r+4qOMG[5nWsKiX-*Rb_iB]s%0q\JFSjl%(h3+[c_/(WH\t@=!O)(>ihg'aMD7nOb%o7Osektko,G'*#Ud`ULLW:5l"&#%PXDoL%#KYYCm7K@`QKn4%:<T4Q%_'Fn=Cm=rZ+s+-,,0+9kSL3,$W87MQn"I-Aj=j%;]\s+8i8iLA1'k,EK8Y2c$78i^T/T\\!1'hb6pL@2#UK,W=,IE`O;ujpOr%Caqdrt<oXlo5=tuL&d3@G</#LsA%$Z3a)2H8%#Emc.KY]m7?4KG\e%139QaANootV;8FffsQ%6n`'8[[Y9(g7q4(i\>`pSD;D4,`();VU<4Mr^_n2MK+T`<NV*o2mid;X-i:`8u@in&3s/`UAj[GB:59\qb*2oS1nLMb)'Z-H["\fD]_s1n'Bp?m?/NKd^k<Ig;pf-jkm78Bb-hPeF1'qqRt[V/6W=q!?*=%A;RHjD0@6-$8sF%kX%h&E,qH[Tb[RuH3\I^[FnmlQnTW^1BJm+O,:5(GWT]X`+;mc\As[68BaCN&#?(=06J@T)/gT8,8]maF<W^OG[hZ5U(l7ij"+ht-I_rGVOBE/-!8,\iT%!GqDYhZ;Eo<W`'6WVhDmV1RY;S3O7@]*,8I=3:_W?N]l5l"I#aFeW[&L727%f#@$#?otd5g7Oc2[J\N1F1=u*").C'RpUOR9Wa*[\G"CjeRZK?"R#s6e3CG<ZiN)e;\G5Zs,Jk_JALGaE:_Afh5-G!f_a17_N4;f_dn!V*-fAjoc)':a77sdM6JQ*]gNR$0O:edVn\%%Fo9KoNrLo)lBb#[gm@:oc+2kdF8r(1X[VEYH;fGR%6g7>0iupZB;fKh`YO7tn#;a88[7?U<dE\:H?4b]Q"A#aa<H1[<G>I<IQ:>2^\H2T[pfP3KY?N@U,?edH4Pp$:$T)#Set_0hR;jgg?`rcS[/@^Bn70=n"k3#=1,?+YR6>??;$1;RkL&<1&1<H<@pY?B!=OU@#?Xlf^ig\f),UK1oD3A!m,!+ph<\Nj%HK"ihBokM/cEEf.'07[0?n:W!3/C6CgkSQ(.lKWkt]SMR%:t4ZcK8H$r`EaDYm`EZ.0#QtJ`9QKEe]e5'jYJqW83`N5Z>d)9q#pd3FueSS:DPZ!4Y:bE+aMC`(*dR$VKJQI1?\!W2&7W'+#Hlf4fq1fB!b^C5(BfK\tTAIt6^>eQp6Vkm[c%52(gf6U'a4+k"l4*Ot4<XmA80/HS*[]2eb_sU9[jm9SD:n&eE9PLDLfZ0UHelQJpO[.%;'=Z%dVZidYs0+\CHk(4UNDuBS-rYqFR2D.i$Sr9-,Zl,C.Nc*aXW5e<kQD$KK01NKI&Hk2EHLV,3d/)rcsB:[!LjPdpO$O)+:/`?[Z37ekn\j_H1LKf*08*:Ej>-SWMXh91l48La"`ioKQMS9SO/fCQ4%[VlkQ.56*m%]*A~>endstream
 endobj
 xref
-0 10
+0 14
 0000000000 65535 f 
 0000000061 00000 n 
 0000000112 00000 n 
 0000000219 00000 n 
 0000000331 00000 n 
-0000000446 00000 n 
-0000000639 00000 n 
-0000000707 00000 n 
-0000001036 00000 n 
-0000001095 00000 n 
+0000000509 00000 n 
+0000000672 00000 n 
+0000000860 00000 n 
+0000001037 00000 n 
+0000001152 00000 n 
+0000001383 00000 n 
+0000001453 00000 n 
+0000001795 00000 n 
+0000001855 00000 n 
 trailer
 <<
 /ID 
-[<8c124a30fe6991bc76cbcb0a6970ca36><8c124a30fe6991bc76cbcb0a6970ca36>]
+[<0e1109096a5f237b2c5df28d868405fe><0e1109096a5f237b2c5df28d868405fe>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 7 0 R
-/Root 6 0 R
-/Size 10
+/Info 11 0 R
+/Root 10 0 R
+/Size 14
 >>
 startxref
-3648
+5242
 %%EOF

--- a/pages/resume.md
+++ b/pages/resume.md
@@ -2,73 +2,88 @@
 layout: page
 menu: false
 title: Resume
-description: Harsimran Sidhu's detailed resume showcasing expertise in cybersecurity, IT infrastructure, and development.
+description: Harsimran Sidhu is a security operations analyst specializing in incident response, threat investigation, detection engineering, and security automation.
 permalink: /resume/
 ---
 
-![Harsimran Sidhu](/assets/img/uploads/pro.webp){: .img-rounded width="200px" height="200px"}
-# Harsimran Sidhu
+{% assign resume = site.data.resume %}
+<div class="resume-page">
+  <section class="resume-hero" aria-labelledby="resume-name">
+    <img class="resume-photo" src="/assets/img/uploads/pro.webp" alt="Harsimran Sidhu" width="180" height="180" decoding="async">
+    <div>
+      <p class="resume-eyebrow">SECURITY OPERATIONS</p>
+      <h1 id="resume-name">{{ resume.name }}</h1>
+      <p class="resume-headline">{{ resume.headline }}</p>
+      <p class="resume-summary">{{ resume.summary }}</p>
+      <div class="resume-actions">
+        <a class="button resume-download" href="/assets/files/Harsimran-Sidhu-Resume.pdf" download="Harsimran-Sidhu-Resume.pdf">Download PDF</a>
+        <a class="button resume-secondary" href="{{ resume.linkedin }}">Connect on LinkedIn</a>
+      </div>
+      <ul class="resume-contact" aria-label="Contact links">
+        <li><a href="mailto:{{ resume.email }}">{{ resume.email }}</a></li>
+        <li><a href="{{ resume.github }}">GitHub</a></li>
+        <li><a href="{{ resume.website }}">harsim.ca</a></li>
+      </ul>
+    </div>
+  </section>
 
-Security Operations and Threat Intelligence Analyst specializing in incident response, endpoint security, WAF investigations and detection engineering. I turn real-world investigations into practical playbooks for security analysts.
+  <div class="resume-layout">
+    <main class="resume-main">
+      <section class="resume-section" aria-labelledby="experience-title">
+        <p class="resume-section-number">01</p>
+        <h2 id="experience-title">Experience</h2>
+        {% for job in resume.experience %}
+          <article class="resume-role">
+            <div class="resume-role-heading">
+              <div>
+                <h3>{{ job.role }}</h3>
+                <p>{{ job.company }} · {{ job.location }}</p>
+              </div>
+              <time>{{ job.dates }}</time>
+            </div>
+            <ul>{% for bullet in job.bullets %}<li>{{ bullet }}</li>{% endfor %}</ul>
+          </article>
+        {% endfor %}
+      </section>
 
-[Download resume (PDF)](/assets/files/Harsimran-Sidhu-Resume.pdf){: .button .resume-download download="Harsimran-Sidhu-Resume.pdf"}
+      <section class="resume-section" aria-labelledby="work-title">
+        <p class="resume-section-number">02</p>
+        <h2 id="work-title">Selected security work</h2>
+        <div class="resume-work-grid">
+          {% for work in resume.selected_work %}
+            <article class="resume-work-card">
+              <h3><a href="{{ work.url | relative_url }}">{{ work.title }}</a></h3>
+              <p>{{ work.description }}</p>
+              <a class="resume-work-link" href="{{ work.url | relative_url }}">Read the case file →</a>
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+    </main>
 
-## Experience
+    <aside class="resume-sidebar" aria-label="Capabilities and education">
+      <section class="resume-section" aria-labelledby="capabilities-title">
+        <p class="resume-section-number">03</p>
+        <h2 id="capabilities-title">Core capabilities</h2>
+        {% for skill in resume.skills %}
+          <div class="resume-skill-group">
+            <h3>{{ skill.group }}</h3>
+            <p>{{ skill.items }}</p>
+          </div>
+        {% endfor %}
+      </section>
 
-### Security Operations Center Analyst
-**Columba System Inc, Remote**  
-_Nov 2022 - Present_
-
-- Monitoring endpoint activities with Cortex XDR to identify potential threats.
-- Implementing Splunk rules and alerts for advanced threat detection.
-- Managing and resolving tickets with Jira for efficient issue tracking.
-- Escalating critical issues to the IT team for rapid response.
-- Automating compliance checks and URL verifications with custom scripts.
-- Analyzing email headers and login patterns to prevent attacks.
-
-### Cyber Security Analyst
-**SecureOps, Remote**  
-_Oct 2021 – Nov 2022_
-
-- Investigating alerts from Microsoft 365 Defender and managing incident escalation.
-- Maintaining clear communication with team members using Microsoft Teams.
-- Daily use of Splunk, Azure Sentinel, and AWS Sandbox within service agreements.
-- Employing Kusto Query Language (KQL) for data filtering during investigations.
-- Packet analysis with Wireshark and familiarity with cybersecurity frameworks.
-
-### Information Technology Specialist
-**Telecom Metrics Inc, Kingston, Ontario**  
-_Jan 2021 – Aug 2021_
-
-- Leading IT security projects for infrastructure development and server maintenance.
-- Providing top-tier customer support and remote troubleshooting.
-- Implementing high availability solutions and automating tasks with Python.
-
-## Skills
-
-- **Problem Solving**: Exceptional at diagnosing and resolving complex issues.
-- **Teamwork**: Collaborative mindset with a history of positive team interactions.
-- **Time Management**: Efficiently prioritizes tasks to meet and exceed deadlines.
-- **Curiosity**: Avid learner, constantly acquiring new technical skills.
-
-**Technical Skills**:
-- Programming: C++, Python
-- Scripting: Shell, Bash
-- Version Control: Proficient with GitHub
-
-## Education
-
-**Cyber Security**
-*University of Toronto CE, Toronto, ON*  
-_Jan 2020 – Aug 2020_  
-Studies focused on cybersecurity strategies and digital information protection.
-
-**Bachelor of Engineering in Technology**
-*Cape Breton University, Sydney, NS*  
-_Sept 2017 – Apr 2019_  
-Emphasis on engineering principles and technological system management.
-
-**Electromechanical Engineering – Advanced Diploma**
-*Humber College, Toronto, ON*  
-_Sept 2013 – Apr 2016_  
-Combination of practical technical skills and electromechanical theory.
+      <section class="resume-section" aria-labelledby="education-title">
+        <p class="resume-section-number">04</p>
+        <h2 id="education-title">Education</h2>
+        {% for item in resume.education %}
+          <article class="resume-education">
+            <h3>{{ item.credential }}</h3>
+            <p>{{ item.school }}</p>
+            <p>{{ item.location }} · {{ item.dates }}</p>
+          </article>
+        {% endfor %}
+      </section>
+    </aside>
+  </div>
+</div>

--- a/scripts/generate_resume_pdf.py
+++ b/scripts/generate_resume_pdf.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate the downloadable resume PDF from _data/resume.json."""
+
+import json
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_LEFT, TA_RIGHT
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import BaseDocTemplate, Frame, KeepTogether, PageTemplate, Paragraph, Spacer, Table, TableStyle
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = ROOT / "_data" / "resume.json"
+OUTPUT_PATH = ROOT / "assets" / "files" / "Harsimran-Sidhu-Resume.pdf"
+RED = colors.HexColor("#E83E4D")
+DARK = colors.HexColor("#151515")
+MID = colors.HexColor("#4A4A4A")
+LIGHT = colors.HexColor("#D7D7D7")
+
+
+def add_page(canvas, doc):
+    canvas.saveState()
+    canvas.setStrokeColor(LIGHT)
+    canvas.setLineWidth(0.5)
+    canvas.line(doc.leftMargin, 0.38 * inch, letter[0] - doc.rightMargin, 0.38 * inch)
+    canvas.setFont("Helvetica", 7)
+    canvas.setFillColor(MID)
+    canvas.drawString(doc.leftMargin, 0.22 * inch, "HARSIMRAN SIDHU / SECURITY OPERATIONS")
+    canvas.drawRightString(letter[0] - doc.rightMargin, 0.22 * inch, f"PAGE {doc.page}")
+    canvas.restoreState()
+
+
+def section_title(text, styles):
+    return [Spacer(1, 5), Paragraph(text.upper(), styles["Section"]), Spacer(1, 2)]
+
+
+def bullet(text, styles):
+    return Paragraph(f"- {escape(text)}", styles["BulletLine"])
+
+
+def build_resume():
+    data = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    doc = BaseDocTemplate(
+        str(OUTPUT_PATH), pagesize=letter,
+        leftMargin=0.48 * inch, rightMargin=0.48 * inch,
+        topMargin=0.4 * inch, bottomMargin=0.5 * inch,
+        title=f"{data['name']} - Resume", author=data["name"],
+        subject="Security Operations, Incident Response, and Threat Intelligence",
+    )
+    frame = Frame(doc.leftMargin, doc.bottomMargin, doc.width, doc.height, id="resume")
+    doc.addPageTemplates([PageTemplate(id="resume", frames=[frame], onPage=add_page)])
+    base = getSampleStyleSheet()
+    styles = {
+        "Name": ParagraphStyle("Name", parent=base["Title"], fontName="Helvetica-Bold", fontSize=24, leading=25, textColor=DARK, alignment=TA_LEFT, spaceAfter=1),
+        "Headline": ParagraphStyle("Headline", parent=base["Normal"], fontName="Helvetica-Bold", fontSize=9, leading=10.4, textColor=RED, tracking=0.8, spaceAfter=3),
+        "Contact": ParagraphStyle("Contact", parent=base["Normal"], fontName="Helvetica", fontSize=7.8, leading=9.4, textColor=MID, spaceAfter=5),
+        "Summary": ParagraphStyle("Summary", parent=base["Normal"], fontName="Helvetica", fontSize=8.6, leading=10.8, textColor=DARK, spaceAfter=2),
+        "Section": ParagraphStyle("Section", parent=base["Heading2"], fontName="Helvetica-Bold", fontSize=9.8, leading=11.2, textColor=RED, spaceBefore=2, spaceAfter=2, tracking=0.7),
+        "Role": ParagraphStyle("Role", parent=base["Heading3"], fontName="Helvetica-Bold", fontSize=9.6, leading=11, textColor=DARK),
+        "Date": ParagraphStyle("Date", parent=base["Normal"], fontName="Helvetica-Bold", fontSize=8, leading=9.4, textColor=RED, alignment=TA_RIGHT),
+        "Company": ParagraphStyle("Company", parent=base["Normal"], fontName="Helvetica-Oblique", fontSize=8, leading=9.4, textColor=MID, spaceAfter=1.5),
+        "BulletLine": ParagraphStyle("BulletLine", parent=base["Normal"], fontName="Helvetica", fontSize=8, leading=9.6, textColor=DARK, leftIndent=7, firstLineIndent=-6, spaceAfter=1.4),
+        "Compact": ParagraphStyle("Compact", parent=base["Normal"], fontName="Helvetica", fontSize=7.8, leading=9.3, textColor=DARK, spaceAfter=2),
+        "Education": ParagraphStyle("Education", parent=base["Normal"], fontName="Helvetica", fontSize=7.8, leading=9.3, textColor=DARK, spaceAfter=1.5),
+    }
+    story = [
+        Paragraph(escape(data["name"]), styles["Name"]),
+        Paragraph(escape(data["headline"].upper()), styles["Headline"]),
+        Paragraph(
+            f"<link href='mailto:{data['email']}'>{data['email']}</link>  |  "
+            f"<link href='{data['website']}'>harsim.ca</link>  |  "
+            f"<link href='{data['linkedin']}'>linkedin.com/in/harsimransidhu</link>  |  "
+            f"<link href='{data['github']}'>github.com/PKHarsimran</link>", styles["Contact"]),
+        Paragraph(escape(data["summary"]), styles["Summary"]),
+    ]
+    story.extend(section_title("Experience", styles))
+    for job in data["experience"]:
+        heading = Table([[Paragraph(escape(job["role"]), styles["Role"]), Paragraph(escape(job["dates"]), styles["Date"]) ]], colWidths=[doc.width * 0.72, doc.width * 0.28])
+        heading.setStyle(TableStyle([("VALIGN", (0, 0), (-1, -1), "TOP"), ("LEFTPADDING", (0, 0), (-1, -1), 0), ("RIGHTPADDING", (0, 0), (-1, -1), 0), ("TOPPADDING", (0, 0), (-1, -1), 0), ("BOTTOMPADDING", (0, 0), (-1, -1), 0)]))
+        block = [heading, Paragraph(f"{escape(job['company'])} | {escape(job['location'])}", styles["Company"])]
+        block.extend(bullet(item, styles) for item in job["bullets"])
+        block.append(Spacer(1, 4))
+        story.append(KeepTogether(block))
+    story.extend(section_title("Core Capabilities", styles))
+    skill_rows = [[Paragraph(f"<b>{escape(skill['group'])}</b>", styles["Compact"]), Paragraph(escape(skill["items"]), styles["Compact"])] for skill in data["skills"]]
+    skills_table = Table(skill_rows, colWidths=[1.22 * inch, doc.width - 1.22 * inch])
+    skills_table.setStyle(TableStyle([("VALIGN", (0, 0), (-1, -1), "TOP"), ("LEFTPADDING", (0, 0), (-1, -1), 0), ("RIGHTPADDING", (0, 0), (-1, -1), 4), ("TOPPADDING", (0, 0), (-1, -1), 0), ("BOTTOMPADDING", (0, 0), (-1, -1), 0)]))
+    story.append(skills_table)
+    story.extend(section_title("Selected Security Work", styles))
+    for work in data["selected_work"]:
+        story.append(Paragraph(f"<b>{escape(work['title'])}:</b> {escape(work['description'])}", styles["Compact"]))
+    story.extend(section_title("Education", styles))
+    education_cells = [Paragraph(f"<b>{escape(item['credential'])}</b><br/>{escape(item['school'])} | {escape(item['location'])}<br/><font color='#E83E4D'>{escape(item['dates'])}</font>", styles["Education"]) for item in data["education"]]
+    education_table = Table([education_cells], colWidths=[doc.width / 3.0] * 3)
+    education_table.setStyle(TableStyle([("VALIGN", (0, 0), (-1, -1), "TOP"), ("LEFTPADDING", (0, 0), (-1, -1), 0), ("RIGHTPADDING", (0, 0), (-1, -1), 8), ("TOPPADDING", (0, 0), (-1, -1), 0), ("BOTTOMPADDING", (0, 0), (-1, -1), 0)]))
+    story.append(education_table)
+    doc.build(story)
+
+
+if __name__ == "__main__":
+    build_resume()


### PR DESCRIPTION
## What changed

- rewrote the professional summary around 4+ years of SOC and IT infrastructure experience
- replaced generic task and soft-skill language with evidence-led incident response, detection, investigation, escalation, and automation bullets
- added an ATS-friendly capability map for Cortex XDR, Splunk, Microsoft Defender, Sentinel, KQL, Wireshark, Python, Docker, Azure, and related workflows
- added selected security work tied to the published WordPress, WAF, ransomware, supply-chain, and engineering case files
- redesigned the web resume for a polished desktop and mobile presentation
- rebuilt the downloadable PDF as a clean one-page recruiter/ATS version
- added a reproducible PDF generator backed by the same structured resume data

## Accuracy guardrails

All claims are grounded in the existing resume, work history, and published projects. No unverified certifications, employers, performance metrics, or inflated outcomes were added.

## Verification

- exact GitHub Pages image build passes
- desktop and 390px mobile resume layouts visually verified
- PDF rendered and inspected at 150 DPI with no clipping or overlap
- PDF re-opened as one Letter-sized page with clean extractable ATS text
- contact, portfolio, and download links verified in the rendered page