### PR TITLE
Add accessible motion and dynamic interactions

### DIFF
--- a/_sass/_animations.scss
+++ b/_sass/_animations.scss
@@ -64,3 +64,64 @@
     opacity: 1;
   }
 }
+
+// Progressive enhancement: JavaScript adds these classes only when
+// IntersectionObserver is available, so content never disappears on failure.
+html.motion-ready .reveal-on-scroll {
+  opacity: 0;
+  transform: translate3d(0, rem(28px), 0) scale(0.985);
+  transition:
+    opacity 650ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms),
+    transform 650ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms);
+  will-change: opacity, transform;
+}
+
+html.motion-ready .reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  will-change: auto;
+}
+
+@keyframes heroReveal {
+  from { opacity: 0; transform: translate3d(0, rem(24px), 0); filter: blur(6px); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); filter: blur(0); }
+}
+
+@keyframes heroDrift {
+  from { transform: scale(1.035) translate3d(0, 0, 0); }
+  to { transform: scale(1.075) translate3d(-0.7%, -0.4%, 0); }
+}
+
+@keyframes headerDrop {
+  from { opacity: 0; transform: translate3d(0, rem(-18px), 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+
+@keyframes filterReveal {
+  from { opacity: 0; transform: translate3d(0, rem(16px), 0) scale(0.97); }
+  to { opacity: 1; transform: translate3d(0, 0, 0) scale(1); }
+}
+
+@keyframes filterPulse {
+  0% { box-shadow: 0 0 0 0 rgba(239, 63, 74, 0.4); }
+  100% { box-shadow: 0 0 0 rem(8px) rgba(239, 63, 74, 0); }
+}
+
+@keyframes lightSweep {
+  0%, 68% { transform: translate3d(-140%, 0, 0) skewX(-18deg); }
+  82%, 100% { transform: translate3d(220%, 0, 0) skewX(-18deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  html.motion-ready .reveal-on-scroll {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -11,7 +11,7 @@
   @include media(">=sm") { min-height: 94vh; }
 
   .hero-art, .hero-shade { position: absolute; inset: 0; width: 100%; height: 100%; }
-  .hero-art { z-index: -2; object-fit: cover; object-position: 69% center; }
+  .hero-art { z-index: -2; object-fit: cover; object-position: 69% center; transform-origin: 70% 50%; }
   .hero-shade {
     z-index: -1;
     background: linear-gradient(90deg, rgba(5, 6, 8, 0.98) 0%, rgba(5, 6, 8, 0.88) 42%, rgba(5, 6, 8, 0.08) 78%), linear-gradient(0deg, #141414 0%, transparent 24%);
@@ -29,14 +29,16 @@
   .buttons { display: flex; flex-wrap: wrap; gap: rem(12px); margin-top: rem(32px); }
   .button {
     display: inline-flex; min-height: rem(48px); align-items: center; justify-content: center; border: 1px solid rgba(255, 255, 255, 0.24); border-radius: rem(5px); padding: rem(11px) rem(19px); color: #fff; font-size: rem(16px); font-weight: 700; text-decoration: none; transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
-    &:hover { transform: translateY(-2px); color: #fff; }
+    &:hover { transform: translateY(-3px); box-shadow: 0 rem(12px) rem(30px) rgba(0, 0, 0, 0.28); color: #fff; }
   }
   .button-primary { border-color: $themeColor; background: $themeColor; }
   .button-secondary:hover { border-color: rgba(255, 255, 255, 0.6); background: rgba(255, 255, 255, 0.08); }
   .hero-latest {
-    display: block; max-width: rem(590px); margin-top: rem(38px); padding: rem(16px) rem(18px); border-left: 3px solid $themeColor; background: rgba(255, 255, 255, 0.06); color: #fff; text-decoration: none; backdrop-filter: blur(8px);
+    position: relative; display: block; max-width: rem(590px); overflow: hidden; margin-top: rem(38px); padding: rem(16px) rem(18px); border-left: 3px solid $themeColor; background: rgba(255, 255, 255, 0.06); color: #fff; text-decoration: none; backdrop-filter: blur(8px); transition: transform 220ms ease, background-color 220ms ease;
     span { display: block; margin-bottom: rem(4px); color: rgba(255, 255, 255, 0.58); font-size: rem(12px); letter-spacing: 0.12em; text-transform: uppercase; }
     strong { line-height: 1.35; }
+    &::after { position: absolute; inset: -30% auto -30% -25%; width: 18%; background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent); content: ""; pointer-events: none; }
+    &:hover { transform: translate3d(rem(5px), 0, 0); background: rgba(255, 255, 255, 0.1); }
     &:hover strong { color: #ef596b; }
   }
   .hero-stats {
@@ -45,4 +47,17 @@
     dt { font-size: rem(24px); font-weight: 700; }
     dd { margin: 0; color: rgba(255, 255, 255, 0.55); font-size: rem(12px); text-transform: uppercase; letter-spacing: 0.08em; }
   }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .bar-header { animation: headerDrop 520ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+  .hero .hero-art { animation: heroDrift 18s ease-in-out infinite alternate; will-change: transform; }
+  .hero .content > * { opacity: 0; animation: heroReveal 760ms cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+  .hero .content > :nth-child(1) { animation-delay: 100ms; }
+  .hero .content > :nth-child(2) { animation-delay: 180ms; }
+  .hero .content > :nth-child(3) { animation-delay: 280ms; }
+  .hero .content > :nth-child(4) { animation-delay: 380ms; }
+  .hero .content > :nth-child(5) { animation-delay: 480ms; }
+  .hero .content > :nth-child(6) { animation-delay: 580ms; }
+  .hero .hero-latest::after { animation: lightSweep 6.5s ease-in-out 1.4s infinite; }
 }

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -55,8 +55,10 @@
   color: rgba(255, 255, 255, 0.72);
   font: inherit;
   cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background-color 180ms ease, color 180ms ease, box-shadow 180ms ease;
 
-  &:hover, &.active { border-color: $themeColor; background: $themeColor; color: #fff; }
+  &:hover { transform: translateY(rem(-2px)); border-color: rgba(239, 63, 74, 0.8); color: #fff; }
+  &.active { border-color: $themeColor; background: $themeColor; color: #fff; }
 }
 
 .no-case-results {
@@ -89,7 +91,7 @@
   margin: 0 0 rem(30px);
   display: inline-block;
   min-height: rem(285px);
-  transition: all 0.3s;
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1), filter 320ms ease;
   position: relative;
   z-index: 1;
 
@@ -117,7 +119,7 @@
 
   &:hover {
     z-index: 2;
-    transform: translateY(rem(-6px));
+    transform: translate3d(0, rem(-9px), 0) scale(1.01);
 
     img {
       -webkit-filter: grayscale(100%);
@@ -126,6 +128,8 @@
     }
 
     .box-body {
+      border-color: rgba(239, 63, 74, 0.45);
+      box-shadow: 0 rem(24px) rem(55px) rgba(0, 0, 0, 0.34);
       time,
       p {
         color: $accentDark;
@@ -138,6 +142,7 @@
 
         .read-icon {
           opacity: 1;
+          transform: scale(1);
         }
       }
     }
@@ -166,6 +171,7 @@
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: rem(6px);
     background: #1b1c1f;
+    transition: border-color 260ms ease, box-shadow 320ms ease;
 
     img {
       width: 100%;
@@ -293,6 +299,8 @@
         border: 2px solid #fff;
         color: $themeColor;
         z-index: 4;
+        transform: scale(0.82);
+        transition: opacity 220ms ease, transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
 
         svg {
           width: rem(48px);
@@ -304,4 +312,13 @@
   .box-info {
     padding: rem(15px);
   }
+}
+
+.box-item.filter-enter {
+  animation: filterReveal 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--filter-delay, 0ms);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .case-filter.active { animation: filterPulse 520ms ease-out; }
 }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -13,6 +13,7 @@
   var searchClose = searchWrapper && searchWrapper.querySelector(".search-close");
   var searchResults = searchWrapper && searchWrapper.querySelector(".search-results");
   var searchStatus = searchWrapper && searchWrapper.querySelector(".search-status");
+  var reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   var searchIndex;
   var previousFocus;
 
@@ -146,6 +147,7 @@
     button.addEventListener("click", function () {
       var filter = button.dataset.filter;
       var count = 0;
+      var visibleIndex = 0;
       filterButtons.forEach(function (item) {
         var active = item === button;
         item.classList.toggle("active", active);
@@ -154,12 +156,52 @@
       caseFiles.forEach(function (item) {
         var visible = filter === "all" || item.dataset.category === filter;
         item.hidden = !visible;
-        if (visible) count += 1;
+        item.classList.remove("filter-enter");
+        if (visible) {
+          count += 1;
+          if (!reduceMotion) {
+            item.style.setProperty("--filter-delay", (Math.min(visibleIndex, 5) * 45) + "ms");
+            window.requestAnimationFrame(function () { item.classList.add("filter-enter"); });
+          }
+          visibleIndex += 1;
+        }
       });
       if (visibleCount) visibleCount.textContent = count.toString();
       if (noResults) noResults.hidden = count !== 0;
     });
   });
+
+  if (!reduceMotion && "IntersectionObserver" in window) {
+    document.documentElement.classList.add("motion-ready");
+    var revealTargets = document.querySelectorAll([
+      ".case-files-heading",
+      ".case-filters",
+      "[data-case-file]",
+      ".resume-hero",
+      ".resume-role",
+      ".resume-work-card",
+      ".resume-skill-group",
+      ".resume-education",
+      ".post-content > h2",
+      ".post-content > h3",
+      ".post-content > figure",
+      ".post-content > blockquote",
+      ".post-content > pre",
+      ".investigation-path"
+    ].join(","));
+    var revealObserver = new IntersectionObserver(function (entries, observer) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        entry.target.classList.add("is-visible");
+        observer.unobserve(entry.target);
+      });
+    }, { rootMargin: "0px 0px -7% 0px", threshold: 0.08 });
+    revealTargets.forEach(function (target, index) {
+      target.classList.add("reveal-on-scroll");
+      target.style.setProperty("--reveal-delay", ((index % 3) * 70) + "ms");
+      revealObserver.observe(target);
+    });
+  }
 
   function copyText(text, button, successLabel) {
     if (!navigator.clipboard) return;


### PR DESCRIPTION
## What changed

- add a staggered, cinematic hero entrance and subtle ambient background drift
- reveal case files, resume sections, and article content as they enter the viewport
- animate category filtering with a short card cascade and active-filter feedback
- refine card, CTA, and latest-investigation hover interactions
- respect `prefers-reduced-motion` and keep content visible when JavaScript or IntersectionObserver is unavailable

## Verification

- exact GitHub Pages build: `ghcr.io/actions/jekyll-build-pages:v1.0.13`
- JavaScript syntax check
- desktop and 390 px mobile visual checks
- menu open/close interaction
- case-file filters and visible result count
- homepage, resume, and investigation page reveal behavior