### PR TITLE
Deep interaction polish and adaptive motion

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,5 @@
     <script>
         document.querySelector('html').classList.remove('no-js');
     </script>
-    <script defer data-domain="harsim.ca" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js"></script>
-    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     {% include stats.html %}
 </head>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,4 +1,4 @@
-<aside class="sidebar" id="sidebar" aria-hidden="true">
+<aside class="sidebar" id="sidebar" role="dialog" aria-modal="true" aria-label="Site navigation" aria-hidden="true">
     <button class="menu-close" type="button" aria-label="Close menu">
       <svg aria-hidden="true"><use xlink:href="#icon-close"></use></svg>
     </button>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,5 +1,5 @@
-<div class="search-wrapper" id="site-search" role="search" aria-hidden="true">
-    <div class="search-form">
+<div class="search-wrapper" id="site-search" role="dialog" aria-modal="true" aria-label="Search case files" aria-hidden="true">
+    <div class="search-form" role="search">
         <p class="search-eyebrow">COMMAND SEARCH</p>
         <h2>Find a case file</h2>
         <p class="search-help">Search by threat, tool, topic, or tactic. Press <kbd>Esc</kbd> to close.</p>

--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -6,6 +6,16 @@
     var hostname = window.location.hostname.replace(/^www\./, "");
     if (hostname !== "harsim.ca") return;
 
+    window.plausible = window.plausible || function () {
+      (window.plausible.q = window.plausible.q || []).push(arguments);
+    };
+
+    var plausibleScript = document.createElement("script");
+    plausibleScript.defer = true;
+    plausibleScript.dataset.domain = "harsim.ca";
+    plausibleScript.src = "https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js";
+    document.head.appendChild(plausibleScript);
+
     window.dataLayer = window.dataLayer || [];
     window.gtag = window.gtag || function () {
       window.dataLayer.push(arguments);

--- a/_layouts/404.html
+++ b/_layouts/404.html
@@ -9,6 +9,11 @@ layout: default
     text-align: center;
     padding-top: 60px;
   }
+  .container > img {
+    width: 100%;
+    height: auto;
+    max-width: 800px;
+  }
 </style>
 
 <div class="container">

--- a/_sass/_animations.scss
+++ b/_sass/_animations.scss
@@ -112,6 +112,30 @@ html.motion-ready .reveal-on-scroll.is-visible {
   82%, 100% { transform: translate3d(220%, 0, 0) skewX(-18deg); }
 }
 
+@keyframes searchResultReveal {
+  from { opacity: 0; transform: translate3d(rem(-12px), 0, 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+
+@keyframes menuItemReveal {
+  from { opacity: 0; transform: translate3d(rem(-18px), 0, 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+
+@keyframes pathStepReveal {
+  from { opacity: 0; transform: translate3d(0, rem(12px), 0); }
+  to { opacity: 1; transform: translate3d(0, 0, 0); }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .investigation-path.reveal-on-scroll li { opacity: 0; }
+  .investigation-path.reveal-on-scroll.is-visible li { animation: pathStepReveal 460ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+  .investigation-path.reveal-on-scroll.is-visible li:nth-child(2) { animation-delay: 70ms; }
+  .investigation-path.reveal-on-scroll.is-visible li:nth-child(3) { animation-delay: 140ms; }
+  .investigation-path.reveal-on-scroll.is-visible li:nth-child(4) { animation-delay: 210ms; }
+  .investigation-path.reveal-on-scroll.is-visible li:nth-child(5) { animation-delay: 280ms; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     scroll-behavior: auto !important;

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -52,6 +52,8 @@
 @media (prefers-reduced-motion: no-preference) {
   .bar-header { animation: headerDrop 520ms cubic-bezier(0.22, 1, 0.36, 1) both; }
   .hero .hero-art { animation: heroDrift 18s ease-in-out infinite alternate; will-change: transform; }
+  .hero.motion-managed:not(.is-in-view) .hero-art,
+  .hero.motion-managed:not(.is-in-view) .hero-latest::after { animation-play-state: paused; }
   .hero .content > * { opacity: 0; animation: heroReveal 760ms cubic-bezier(0.22, 1, 0.36, 1) forwards; }
   .hero .content > :nth-child(1) { animation-delay: 100ms; }
   .hero .content > :nth-child(2) { animation-delay: 180ms; }

--- a/_sass/_menu.scss
+++ b/_sass/_menu.scss
@@ -33,6 +33,14 @@ aside.sidebar {
     transition-delay: 0s;
   }
 
+  @media (prefers-reduced-motion: no-preference) {
+    &.open nav li { animation: menuItemReveal 420ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+    &.open nav li:nth-child(2) { animation-delay: 35ms; }
+    &.open nav li:nth-child(3) { animation-delay: 70ms; }
+    &.open nav li:nth-child(4) { animation-delay: 105ms; }
+    &.open nav li:nth-child(5) { animation-delay: 140ms; }
+  }
+
   .menu-close {
     position: absolute;
     top: rem(8px);

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -30,7 +30,7 @@
 }
 
 .post-content {
-  overflow-x: auto;
+  min-width: 0;
   padding: rem(40px) 0;
 
   &.fullwidth {
@@ -340,8 +340,7 @@
 
 .article-tools {
   @include center(rem(800px));
-  position: sticky;
-  top: rem(66px);
+  position: static;
   z-index: 5;
   display: flex;
   flex-wrap: wrap;
@@ -355,6 +354,11 @@
   background: rgba(255, 255, 255, 0.96);
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
   backdrop-filter: blur(10px);
+
+  @include media(">=sm") {
+    position: sticky;
+    top: rem(82px);
+  }
 
   button, summary {
     min-height: rem(44px);
@@ -387,7 +391,12 @@
     box-shadow: 0 15px 40px rgba(0, 0, 0, 0.13);
   }
   li { padding: rem(4px) 0; font-size: rem(14px); line-height: 1.35; }
-  a { color: $primaryDark; }
+  a {
+    display: inline-block;
+    color: $primaryDark;
+    transition: color 180ms ease, transform 180ms ease;
+  }
+  a[aria-current="location"] { transform: translateX(rem(4px)); color: $themeColor; font-weight: 700; }
 }
 
 .investigation-path {

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -686,13 +686,17 @@
 
     .image {
       display: none;
-      flex: 0 0 rem(110px);
+      flex: 0 0 rem(140px);
       height: rem(72px);
       overflow: hidden;
       border-radius: rem(4px);
 
-      @include media(">=sm") {
+      @media (min-width: 48rem) {
         display: block;
+        height: rem(88px);
+      }
+
+      @media (min-width: 64rem) {
         flex-basis: rem(180px);
         height: rem(110px);
       }
@@ -717,9 +721,15 @@
       transition: color 0.3s;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
-      @include media(">=sm") {
+
+      @media (min-width: 48rem) {
+        font-size: rem(18px);
+        margin-left: rem(16px);
+      }
+
+      @media (min-width: 64rem) {
         font-size: rem(19px);
-        margin: 0 0 0 rem(20px);
+        margin-left: rem(20px);
         -webkit-line-clamp: 2;
       }
     }

--- a/_sass/_search.scss
+++ b/_sass/_search.scss
@@ -78,6 +78,10 @@
       display: block;
     }
 
+    @media (prefers-reduced-motion: no-preference) {
+      li { animation: searchResultReveal 360ms cubic-bezier(0.22, 1, 0.36, 1) both; animation-delay: var(--search-delay, 0ms); }
+    }
+
     .entry-date {
       float: right;
       display: none;

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -16,6 +16,8 @@
   var reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   var searchIndex;
   var searchEventTimer;
+  var searchRenderTimer;
+  var searchRequestId = 0;
   var previousFocus;
 
   function trackEvent(name, parameters) {
@@ -23,7 +25,29 @@
     window.gtag("event", name, parameters || {});
   }
 
+  function focusableElements(container) {
+    return Array.from(container.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), summary, [tabindex]:not([tabindex="-1"])')).filter(function (element) {
+      return element.getClientRects().length > 0 && element.getAttribute("aria-hidden") !== "true";
+    });
+  }
+
+  function trapFocus(container, event) {
+    if (event.key !== "Tab") return;
+    var focusable = focusableElements(container);
+    if (!focusable.length) return;
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    if (event.shiftKey && (document.activeElement === first || !container.contains(document.activeElement))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   function openMenu() {
+    if (body.classList.contains("search-overlay")) closeSearch(false);
     body.classList.add("menu-open");
     sidebar.classList.add("open");
     mask.classList.add("show");
@@ -34,14 +58,14 @@
     trackEvent("navigation_menu_open");
   }
 
-  function closeMenu() {
+  function closeMenu(restoreFocus) {
     body.classList.remove("menu-open");
     sidebar.classList.remove("open");
     mask.classList.remove("show");
     sidebar.setAttribute("aria-hidden", "true");
     menuButton.setAttribute("aria-expanded", "false");
     menuButton.setAttribute("aria-label", "Open menu");
-    menuButton.focus();
+    if (restoreFocus !== false) menuButton.focus();
   }
 
   function loadSearchIndex() {
@@ -61,7 +85,10 @@
 
   function openSearch() {
     if (!searchWrapper || !searchForm || !searchInput) return;
-    previousFocus = document.activeElement;
+    var openedFromMenu = body.classList.contains("menu-open");
+    var searchTrigger = document.activeElement;
+    if (openedFromMenu) closeMenu(false);
+    previousFocus = openedFromMenu ? (menuButton || searchTrigger) : searchTrigger;
     searchWrapper.classList.add("active");
     searchForm.classList.add("active");
     searchWrapper.setAttribute("aria-hidden", "false");
@@ -72,16 +99,20 @@
     trackEvent("search_open");
   }
 
-  function closeSearch() {
+  function closeSearch(restoreFocus) {
     if (!searchWrapper || !searchForm) return;
     searchWrapper.classList.remove("active");
     searchForm.classList.remove("active");
     searchWrapper.setAttribute("aria-hidden", "true");
     searchButton.setAttribute("aria-expanded", "false");
     body.classList.remove("search-overlay");
+    searchRequestId += 1;
+    window.clearTimeout(searchRenderTimer);
+    window.clearTimeout(searchEventTimer);
+    searchInput.value = "";
     searchResults.replaceChildren();
     if (searchStatus) searchStatus.textContent = "";
-    if (previousFocus && previousFocus.focus) previousFocus.focus();
+    if (restoreFocus !== false && previousFocus && previousFocus.focus) previousFocus.focus();
   }
 
   function renderSearchResults(posts, query) {
@@ -96,6 +127,7 @@
       date.className = "entry-date";
       date.textContent = post.date;
       link.href = post.url;
+      item.style.setProperty("--search-delay", (Math.min(searchResults.children.length, 7) * 35) + "ms");
       link.addEventListener("click", function () {
         trackEvent("select_content", {
           content_type: "search_result",
@@ -103,6 +135,18 @@
           item_name: post.title,
           search_term: query
         });
+      });
+      link.addEventListener("keydown", function (event) {
+        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+        event.preventDefault();
+        var links = Array.from(searchResults.querySelectorAll("a"));
+        var index = links.indexOf(link);
+        if (event.key === "ArrowUp" && index === 0) {
+          searchInput.focus();
+          return;
+        }
+        var nextIndex = event.key === "ArrowDown" ? Math.min(index + 1, links.length - 1) : Math.max(index - 1, 0);
+        links[nextIndex].focus();
       });
       link.append(category, document.createTextNode(post.title + " "), date);
       item.appendChild(link);
@@ -129,18 +173,31 @@
   if (searchButton && searchWrapper && searchInput && searchClose && searchResults) {
     searchButton.addEventListener("click", openSearch);
     searchClose.addEventListener("click", closeSearch);
+    searchInput.addEventListener("keydown", function (event) {
+      if (event.key !== "ArrowDown") return;
+      var firstResult = searchResults.querySelector("a");
+      if (!firstResult) return;
+      event.preventDefault();
+      firstResult.focus();
+    });
     searchInput.addEventListener("input", function () {
       var query = searchInput.value.trim().toLowerCase();
+      var requestId = ++searchRequestId;
+      window.clearTimeout(searchRenderTimer);
       if (query.length < 2) {
+        window.clearTimeout(searchEventTimer);
         searchResults.replaceChildren();
         searchStatus.textContent = query.length ? "Type one more character to search." : "";
         return;
       }
-      loadSearchIndex().then(function (posts) {
-        renderSearchResults(posts.filter(function (post) {
-          return [post.title, post.tags, post.categories, post.description, post.content].join(" ").toLowerCase().includes(query);
-        }), query);
-      });
+      searchRenderTimer = window.setTimeout(function () {
+        loadSearchIndex().then(function (posts) {
+          if (requestId !== searchRequestId || searchInput.value.trim().toLowerCase() !== query) return;
+          renderSearchResults(posts.filter(function (post) {
+            return [post.title, post.tags, post.categories, post.description, post.content].join(" ").toLowerCase().includes(query);
+          }), query);
+        });
+      }, 140);
     });
   }
 
@@ -149,6 +206,8 @@
   });
 
   document.addEventListener("keydown", function (event) {
+    if (body.classList.contains("search-overlay")) trapFocus(searchWrapper, event);
+    if (body.classList.contains("menu-open")) trapFocus(sidebar, event);
     if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
       event.preventDefault();
       body.classList.contains("search-overlay") ? closeSearch() : openSearch();
@@ -258,6 +317,17 @@
       target.style.setProperty("--reveal-delay", ((index % 3) * 70) + "ms");
       revealObserver.observe(target);
     });
+
+    var hero = document.querySelector(".hero");
+    if (hero) {
+      hero.classList.add("motion-managed");
+      var heroObserver = new IntersectionObserver(function (entries) {
+        entries.forEach(function (entry) {
+          entry.target.classList.toggle("is-in-view", entry.isIntersecting);
+        });
+      }, { threshold: 0.08 });
+      heroObserver.observe(hero);
+    }
   }
 
   function copyText(text, button, successLabel) {
@@ -285,6 +355,8 @@
   });
 
   var tocList = document.querySelector("[data-toc-list]");
+  var tocHeadings = [];
+  var tocLinks = [];
   if (tocList) {
     document.querySelectorAll(".post-content > h2, .post-content > h3").forEach(function (heading, index) {
       if (heading.closest(".investigation-path")) return;
@@ -293,11 +365,29 @@
       var link = document.createElement("a");
       link.href = "#" + heading.id;
       link.textContent = heading.textContent;
+      link.addEventListener("click", function () {
+        var details = tocList.closest("details");
+        if (details) details.open = false;
+      });
       if (heading.tagName === "H3") item.className = "toc-subsection";
       item.appendChild(link);
       tocList.appendChild(item);
+      tocHeadings.push(heading);
+      tocLinks.push(link);
     });
     if (!tocList.children.length) tocList.closest("details").hidden = true;
+  }
+
+  function updateTocState() {
+    if (!tocHeadings.length) return;
+    var currentIndex = 0;
+    tocHeadings.forEach(function (heading, index) {
+      if (heading.getBoundingClientRect().top <= 150) currentIndex = index;
+    });
+    tocLinks.forEach(function (link, index) {
+      if (index === currentIndex) link.setAttribute("aria-current", "location");
+      else link.removeAttribute("aria-current");
+    });
   }
 
   var printButton = document.querySelector("[data-print-playbook]");
@@ -350,13 +440,16 @@
         });
       });
     }
+    updateTocState();
     ticking = false;
   }
-  window.addEventListener("scroll", function () {
+  function scheduleScrollUpdate() {
     if (!ticking) {
       window.requestAnimationFrame(updateScrollState);
       ticking = true;
     }
-  }, { passive: true });
+  }
+  window.addEventListener("scroll", scheduleScrollUpdate, { passive: true });
+  window.addEventListener("resize", scheduleScrollUpdate, { passive: true });
   updateScrollState();
 })();


### PR DESCRIPTION
## Bugs fixed

- stop the 404 illustration from creating 410 px of horizontal overflow on mobile
- clear stale search queries and cancel outdated/debounced searches when the overlay closes
- prevent older async search results from replacing a newer query
- make menu and search mutually exclusive instead of allowing overlapping overlays
- contain keyboard focus within open menu/search dialogs and restore it correctly on close
- add Arrow Up/Down navigation through search results
- restore the article tool bar's sticky behavior by removing the parent overflow container that disabled it
- keep the large mobile article tool bar non-sticky so it does not consume reading space
- update reading progress and active section state after viewport resizing
- load Plausible only on the production hostname, matching the existing GA4 guard
- keep long recommendation titles readable across the 600–1024 px transition by delaying and progressively sizing the thumbnail

## Smarter motion and feedback

- pause the ambient hero animation whenever the hero is off-screen
- stagger search results as they appear
- stagger sidebar navigation items when the menu opens
- sequence investigation-path steps when they enter the viewport
- highlight and gently shift the current table-of-contents section while reading
- preserve the existing `prefers-reduced-motion` behavior for every new effect

## Verification

- exact GitHub Pages build with `ghcr.io/actions/jekyll-build-pages:v1.0.13`
- JavaScript syntax and whitespace checks
- generated-site internal link audit: 0 broken links
- all declared post image dimensions match the source assets
- representative 1440 × 900 and 390 × 844 layout audit across home, resume, about, contact, category, tags, article, and 404 pages
- recommendation preview sweep at 599, 600, 620, 700, 767, 768, 900, 1023, 1024, and 1440 px with the full UniversalWebTracker title visible and no horizontal overflow
- mobile 404 overflow reduced from 410 px to 0
- keyboard search navigation, query reset, and focus wrapping tested
- desktop article tools remain sticky at the correct header offset; mobile tools remain static
- active table-of-contents state, compact recommendation panel, and hero pause/resume behavior tested
- clean final browser console