### PR TITLE
Fix stretched author portrait

### DIFF
--- a/_sass/_author.scss
+++ b/_sass/_author.scss
@@ -37,12 +37,19 @@
 
   img {
     width: rem(150px);
+    height: rem(150px);
+    aspect-ratio: 1;
+    object-fit: cover;
+    object-position: center 30%;
     border-radius: 50%;
+    border: rem(4px) solid rgba(255, 255, 255, 0.72);
+    box-shadow: 0 rem(10px) rem(30px) rgba(0, 0, 0, 0.1);
     display: block;
     margin: auto;
 
     @include media(">=sm") {
       width: rem(180px);
+      height: rem(180px);
       float: left;
       margin-right: 3.125rem;
     }


### PR DESCRIPTION
## Fix

- render the author portrait with matching responsive width and height instead of allowing the HTML height to stretch it
- enforce a 1:1 crop with `aspect-ratio` and `object-fit: cover`
- preserve the face as the focal point with an adjusted object position
- add a subtle border and shadow so the portrait reads cleanly against the author panel

## Verification

- exact GitHub Pages build with `ghcr.io/actions/jekyll-build-pages:v1.0.13`
- visually checked the author panel at 390, 599, 600, 768, and 1440 px
- portrait ratio remains exactly 1:1 at every tested width
- zero horizontal overflow at every tested width