### PR TITLE
Resolve legacy Bundler security alerts

### DIFF
--- a/jekflix.gemspec
+++ b/jekflix.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-paginate", "1.1.0"
   spec.add_runtime_dependency "jekyll-paginate-content", "1.1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 2.2.33", "< 5"
   spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
## Security fix

Raise the Bundler development dependency from `~> 1.16` to `>= 2.2.33, < 5`.

This closes the vulnerable version ranges for:

- CVE-2016-7954 — secondary source code injection; Bundler 1.x is affected
- CVE-2019-3881 — insecure temporary path handling; patched in 2.1.0
- CVE-2020-36327 — dependency confusion; patched lines culminate in 2.2.18
- CVE-2021-43809 — git URL argument injection; patched in 2.2.33

The 2.2.33 floor is above every affected range, and the upper bound keeps future major-version changes explicit while allowing the repository's currently locked Bundler 4.0.19.

## Verification

- vulnerable releases through 2.2.32 are rejected by the gemspec
- patched releases 2.2.33, 2.4.22, and locked 4.0.19 are accepted
- `gem build jekflix.gemspec` succeeds without warnings
- the Gemfile retains one HTTPS source: `https://rubygems.org`
- exact GitHub Pages build succeeds with `ghcr.io/actions/jekyll-build-pages:v1.0.13`
- GitHub Actions validation passes