### PR TITLE
Add a privacy-first IOC Workbench

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ show_hero: true
 menu:
   - title: Home
     url: /
+  - title: IOC Workbench
+    url: /ioc-workbench/
   - title: Resume
     url: /resume
   - title: About

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -36,6 +36,15 @@ layout: main
     {% endif %}
 
     <section class="case-files" id="case-files" aria-labelledby="case-files-title">
+        <a class="home-tool-callout" href="{{ '/ioc-workbench/' | relative_url }}">
+            <span class="home-tool-mark" aria-hidden="true">⌁</span>
+            <span class="home-tool-copy">
+                <span class="home-tool-label">NEW · BROWSER TOOL</span>
+                <strong>IOC Workbench</strong>
+                <span>Extract, defang, deduplicate, and export investigation artifacts—without uploading them.</span>
+            </span>
+            <span class="home-tool-action">Launch tool <span aria-hidden="true">→</span></span>
+        </a>
         <div class="case-files-heading">
             <div>
                 <p class="section-kicker">FIELD NOTES</p>

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -36,6 +36,97 @@
   }
 }
 
+.home-tool-callout {
+  @include center(rem(1134px));
+  position: relative;
+  display: grid;
+  grid-template-columns: rem(54px) minmax(0, 1fr) auto;
+  gap: rem(20px);
+  align-items: center;
+  overflow: hidden;
+  margin-bottom: rem(58px);
+  padding: rem(22px) rem(25px);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: rem(10px);
+  background: linear-gradient(110deg, #1d2024, #17181b);
+  color: #fff;
+  text-decoration: none;
+  transition: border-color 180ms ease, box-shadow 220ms ease, transform 220ms ease;
+
+  &::after {
+    position: absolute;
+    top: -80%;
+    right: 5%;
+    width: rem(180px);
+    height: rem(180px);
+    border-radius: 50%;
+    background: rgba(208, 0, 18, 0.15);
+    filter: blur(rem(34px));
+    content: "";
+    pointer-events: none;
+  }
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba(239, 89, 107, 0.65);
+    box-shadow: 0 rem(20px) rem(45px) rgba(0, 0, 0, 0.3);
+    color: #fff;
+    transform: translateY(rem(-4px));
+  }
+
+  &:focus-visible { outline: rem(3px) solid rgba(239, 89, 107, 0.38); outline-offset: rem(3px); }
+}
+
+.home-tool-mark {
+  display: grid;
+  width: rem(54px);
+  height: rem(54px);
+  place-items: center;
+  border: 1px solid rgba(239, 89, 107, 0.35);
+  border-radius: rem(8px);
+  background: rgba(208, 0, 18, 0.14);
+  color: #ff6b7c;
+  font-size: rem(28px);
+}
+
+.home-tool-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+
+  strong { font-size: rem(23px); line-height: 1.15; }
+  > span:last-child { margin-top: rem(4px); color: rgba(255, 255, 255, 0.62); font-size: rem(14px); line-height: 1.4; }
+}
+
+.home-tool-label {
+  margin-bottom: rem(5px);
+  color: #ef596b;
+  font-size: rem(11px);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.home-tool-action {
+  z-index: 1;
+  color: #fff;
+  font-size: rem(14px);
+  font-weight: 700;
+  white-space: nowrap;
+
+  span { margin-left: rem(5px); color: #ef596b; font-size: rem(20px); }
+}
+
+@include media("<sm") {
+  .home-tool-callout {
+    grid-template-columns: rem(46px) minmax(0, 1fr);
+    margin: 0 rem(14px) rem(48px);
+    padding: rem(19px);
+  }
+
+  .home-tool-mark { width: rem(46px); height: rem(46px); }
+  .home-tool-action { grid-column: 2; }
+}
+
 .case-filters {
   @include center(rem(1180px));
   display: flex;

--- a/_sass/_ioc-workbench.scss
+++ b/_sass/_ioc-workbench.scss
@@ -1,0 +1,490 @@
+.ioc-workbench {
+  --ioc-ink: #111820;
+  --ioc-muted: #5f6b76;
+  --ioc-line: #dce2e7;
+  --ioc-surface: #f4f7f8;
+  --ioc-accent: #{$themeColor};
+  max-width: rem(1120px);
+  margin: 0 auto;
+  padding: rem(112px) rem(24px) rem(72px);
+  color: var(--ioc-ink);
+  @include mainFont(300);
+
+  .screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  button,
+  textarea,
+  input {
+    font: inherit;
+  }
+}
+
+.ioc-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) rem(260px);
+  gap: rem(54px);
+  align-items: center;
+  overflow: hidden;
+  padding: clamp(#{rem(32px)}, 6vw, #{rem(68px)});
+  border-radius: rem(18px);
+  background:
+    radial-gradient(circle at 80% 15%, rgba(208, 0, 18, 0.24), transparent 35%),
+    linear-gradient(135deg, #111820, #17232d);
+  box-shadow: 0 rem(28px) rem(70px) rgba(17, 24, 32, 0.2);
+  color: #fff;
+
+  &::after {
+    position: absolute;
+    inset: 0;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: inherit;
+    content: "";
+    pointer-events: none;
+  }
+
+  h1 {
+    max-width: rem(700px);
+    margin: 0 0 rem(18px);
+    font-size: clamp(#{rem(38px)}, 6vw, #{rem(68px)});
+    line-height: 0.98;
+    letter-spacing: rem(-1.8px);
+  }
+
+  p:not(.ioc-eyebrow) {
+    max-width: rem(680px);
+    margin: 0;
+    color: #d8e0e6;
+    font-size: clamp(#{rem(18px)}, 2.2vw, #{rem(22px)});
+    line-height: 1.45;
+  }
+}
+
+.ioc-eyebrow,
+.ioc-step {
+  margin: 0 0 rem(14px);
+  color: var(--ioc-accent);
+  font-size: rem(13px);
+  font-weight: 700;
+  letter-spacing: rem(1.7px);
+  text-transform: uppercase;
+}
+
+.ioc-eyebrow {
+  display: flex;
+  gap: rem(9px);
+  align-items: center;
+
+  span {
+    width: rem(8px);
+    height: rem(8px);
+    border-radius: 50%;
+    background: #ff5361;
+    box-shadow: 0 0 0 rem(6px) rgba(255, 83, 97, 0.12);
+    animation: ioc-pulse 2.2s ease-in-out infinite;
+  }
+}
+
+.ioc-trust-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem(10px);
+  margin: rem(28px) 0 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    padding: rem(7px) rem(12px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: rem(999px);
+    color: #fff;
+    font-size: rem(13px);
+    font-weight: 700;
+  }
+}
+
+.ioc-signal {
+  position: relative;
+  display: flex;
+  gap: rem(12px);
+  align-items: center;
+  justify-content: center;
+  height: rem(220px);
+
+  &::before,
+  &::after {
+    position: absolute;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 50%;
+    content: "";
+  }
+
+  &::before { width: rem(210px); height: rem(210px); }
+  &::after { width: rem(150px); height: rem(150px); }
+
+  span {
+    z-index: 1;
+    width: rem(7px);
+    min-height: rem(30px);
+    border-radius: rem(8px);
+    background: linear-gradient(#ff5361, var(--ioc-accent));
+    animation: ioc-signal 1.25s ease-in-out infinite alternate;
+
+    &:nth-child(2) { height: 42%; animation-delay: -0.8s; }
+    &:nth-child(3) { height: 70%; animation-delay: -0.25s; }
+    &:nth-child(4) { height: 48%; animation-delay: -1s; }
+    &:nth-child(5) { height: 28%; animation-delay: -0.5s; }
+  }
+}
+
+.ioc-panel,
+.ioc-results,
+.ioc-guidance {
+  margin-top: rem(30px);
+  padding: clamp(#{rem(24px)}, 4vw, #{rem(42px)});
+  border: 1px solid var(--ioc-line);
+  border-radius: rem(15px);
+  background: #fff;
+  box-shadow: 0 rem(15px) rem(40px) rgba(28, 43, 55, 0.07);
+}
+
+.ioc-panel-heading {
+  display: flex;
+  gap: rem(24px);
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: rem(24px);
+
+  h2 {
+    margin: 0;
+    font-size: clamp(#{rem(28px)}, 4vw, #{rem(38px)});
+    line-height: 1.08;
+  }
+}
+
+.ioc-label {
+  display: block;
+  margin-bottom: rem(8px);
+  font-size: rem(15px);
+  font-weight: 700;
+}
+
+.ioc-workbench textarea {
+  width: 100%;
+  min-height: rem(210px);
+  resize: vertical;
+  padding: rem(20px);
+  border: 1px solid #bac4cb;
+  border-radius: rem(10px);
+  outline: none;
+  background: #101820;
+  box-shadow: inset 0 rem(2px) rem(12px) rgba(0, 0, 0, 0.18);
+  color: #eaf0f3;
+  caret-color: #ff5361;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: rem(15px);
+  line-height: 1.6;
+
+  &::placeholder { color: #8997a2; }
+  &:focus { border-color: var(--ioc-accent); box-shadow: 0 0 0 rem(4px) rgba(208, 0, 18, 0.13); }
+}
+
+.ioc-input-hint,
+.ioc-lookup-note {
+  color: var(--ioc-muted);
+  font-size: rem(14px);
+  line-height: 1.45;
+}
+
+.ioc-input-hint {
+  margin: rem(9px) 0 0;
+
+  code { color: #394650; }
+  kbd {
+    padding: rem(1px) rem(5px);
+    border: 1px solid #c7cfd4;
+    border-bottom-width: rem(2px);
+    border-radius: rem(4px);
+    background: #fff;
+    color: #394650;
+    font-size: rem(12px);
+  }
+}
+
+.ioc-actions,
+.ioc-result-toolbar > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem(10px);
+}
+
+.ioc-actions { margin-top: rem(24px); }
+
+.ioc-primary-button,
+.ioc-secondary-button,
+.ioc-text-button,
+.ioc-item-actions a,
+.ioc-item-actions button {
+  min-height: rem(46px);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease, background 160ms ease;
+
+  &:hover { transform: translateY(rem(-2px)); }
+  &:focus-visible { outline: rem(3px) solid rgba(208, 0, 18, 0.25); outline-offset: rem(2px); }
+}
+
+.ioc-primary-button,
+.ioc-secondary-button {
+  padding: rem(11px) rem(18px);
+  border-radius: rem(7px);
+  font-weight: 700;
+}
+
+.ioc-primary-button {
+  border: 1px solid var(--ioc-accent);
+  background: var(--ioc-accent);
+  box-shadow: 0 rem(9px) rem(22px) rgba(208, 0, 18, 0.2);
+  color: #fff;
+
+  span { margin-right: rem(6px); }
+}
+
+.ioc-secondary-button {
+  border: 1px solid #b9c2c9;
+  background: #fff;
+  color: var(--ioc-ink);
+
+  &:hover { border-color: #71808c; box-shadow: 0 rem(7px) rem(16px) rgba(28, 43, 55, 0.1); }
+}
+
+.ioc-text-button {
+  padding: rem(8px) rem(4px);
+  border: 0;
+  background: transparent;
+  color: #a6000e;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: rem(4px);
+}
+
+.ioc-empty {
+  padding: rem(58px) rem(20px);
+  border: 1px dashed #bdc7ce;
+  border-radius: rem(11px);
+  background: var(--ioc-surface);
+  text-align: center;
+
+  &[hidden] { display: none; }
+
+  > span { display: block; color: #8b98a2; font-size: rem(42px); }
+  h3 { margin: rem(9px) 0 rem(4px); font-size: rem(22px); }
+  p { margin: 0; color: var(--ioc-muted); }
+}
+
+.ioc-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(rem(118px), 1fr));
+  gap: rem(10px);
+  margin-bottom: rem(22px);
+}
+
+.ioc-summary-item {
+  padding: rem(15px);
+  border: 1px solid var(--ioc-line);
+  border-top: rem(3px) solid var(--ioc-accent);
+  border-radius: rem(8px);
+  background: var(--ioc-surface);
+
+  strong { display: block; font-size: rem(26px); line-height: 1; }
+  span { color: var(--ioc-muted); font-size: rem(13px); font-weight: 700; }
+}
+
+.ioc-mode {
+  display: flex;
+  gap: rem(4px);
+  margin: 0;
+  padding: rem(4px);
+  border: 1px solid var(--ioc-line);
+  border-radius: rem(8px);
+  background: var(--ioc-surface);
+
+  label {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-height: rem(38px);
+    padding: rem(7px) rem(12px);
+    border-radius: rem(5px);
+    cursor: pointer;
+    font-size: rem(14px);
+    font-weight: 700;
+  }
+
+  input { position: absolute; opacity: 0; }
+  label:has(input:checked) { background: #fff; box-shadow: 0 rem(2px) rem(8px) rgba(28, 43, 55, 0.1); }
+  label:has(input:focus-visible) { outline: rem(3px) solid rgba(208, 0, 18, 0.25); }
+}
+
+.ioc-result-toolbar {
+  display: flex;
+  gap: rem(16px);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: rem(15px);
+
+  p { margin: 0; color: var(--ioc-muted); font-size: rem(14px); }
+}
+
+.ioc-list {
+  display: grid;
+  gap: rem(9px);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ioc-item {
+  display: grid;
+  grid-template-columns: rem(150px) minmax(0, 1fr) auto;
+  gap: rem(18px);
+  align-items: center;
+  min-width: 0;
+  padding: rem(16px);
+  border: 1px solid var(--ioc-line);
+  border-radius: rem(9px);
+  background: #fff;
+  animation: ioc-reveal 320ms ease both;
+  animation-delay: calc(var(--ioc-index) * 35ms);
+
+  code {
+    overflow: hidden;
+    padding: 0;
+    background: transparent;
+    color: #26343e;
+    font-size: rem(14px);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.ioc-item-heading {
+  display: flex;
+  flex-direction: column;
+  gap: rem(4px);
+
+  > span:last-child { color: var(--ioc-muted); font-size: rem(12px); }
+}
+
+.ioc-type {
+  width: max-content;
+  padding: rem(3px) rem(8px);
+  border-radius: rem(999px);
+  background: #ffe5e8;
+  color: #94000c;
+  font-size: rem(12px);
+  font-weight: 700;
+  letter-spacing: rem(0.4px);
+  text-transform: uppercase;
+}
+
+.ioc-item-actions {
+  display: flex;
+  gap: rem(6px);
+
+  a,
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: rem(44px);
+    padding: rem(7px) rem(10px);
+    border: 1px solid #c2cbd1;
+    border-radius: rem(5px);
+    background: #fff;
+    color: #283640;
+    font-size: rem(12px);
+    font-weight: 700;
+    text-decoration: none;
+  }
+}
+
+.ioc-lookup-note { margin: rem(15px) 0 0; }
+
+.ioc-guidance {
+  border-left: rem(5px) solid var(--ioc-accent);
+
+  h2 { margin: 0 0 rem(10px); font-size: clamp(#{rem(25px)}, 3.5vw, #{rem(34px)}); }
+  > p:last-child { max-width: rem(850px); margin: 0; color: var(--ioc-muted); line-height: 1.6; }
+}
+
+@keyframes ioc-pulse {
+  50% { box-shadow: 0 0 0 rem(10px) rgba(255, 83, 97, 0); }
+}
+
+@keyframes ioc-signal {
+  from { height: 18%; opacity: 0.55; }
+  to { height: 72%; opacity: 1; }
+}
+
+@keyframes ioc-reveal {
+  from { opacity: 0; transform: translateY(rem(8px)); }
+  to { opacity: 1; transform: none; }
+}
+
+@include media("<56rem") {
+  .ioc-item {
+    grid-template-columns: rem(120px) minmax(0, 1fr);
+
+    .ioc-item-actions { grid-column: 1 / -1; }
+  }
+}
+
+@include media("<sm") {
+  .ioc-workbench { padding: rem(88px) rem(14px) rem(50px); }
+
+  .ioc-hero {
+    grid-template-columns: 1fr;
+    gap: rem(12px);
+
+    h1 { letter-spacing: rem(-1px); }
+  }
+
+  .ioc-signal { display: none; }
+
+  .ioc-panel-heading,
+  .ioc-result-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .ioc-mode { align-self: flex-start; }
+
+  .ioc-item {
+    grid-template-columns: 1fr;
+    gap: rem(12px);
+
+    code { white-space: normal; overflow-wrap: anywhere; }
+    .ioc-item-actions { grid-column: auto; flex-wrap: wrap; }
+  }
+
+  .ioc-result-toolbar > div {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ioc-eyebrow span,
+  .ioc-signal span,
+  .ioc-item { animation: none; }
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -21,6 +21,7 @@
 @import "form";
 @import "author";
 @import "resume";
+@import "ioc-workbench";
 @import "staff";
 @import "modal";
 @import "footer";

--- a/assets/js/ioc-workbench.js
+++ b/assets/js/ioc-workbench.js
@@ -1,0 +1,328 @@
+(function () {
+  "use strict";
+
+  var root = document.querySelector("[data-ioc-workbench]");
+  if (!root) return;
+
+  var input = root.querySelector("[data-ioc-input]");
+  var analyzeButton = root.querySelector("[data-ioc-analyze]");
+  var clearButton = root.querySelector("[data-ioc-clear]");
+  var sampleButton = root.querySelector("[data-ioc-sample]");
+  var emptyState = root.querySelector("[data-ioc-empty]");
+  var output = root.querySelector("[data-ioc-output]");
+  var summary = root.querySelector("[data-ioc-summary]");
+  var list = root.querySelector("[data-ioc-list]");
+  var status = root.querySelector("[data-ioc-status]");
+  var modeFieldset = root.querySelector("[data-ioc-mode]");
+  var copyButton = root.querySelector("[data-ioc-copy]");
+  var exportButton = root.querySelector("[data-ioc-export]");
+  var indicators = [];
+  var displayMode = "defanged";
+
+  var typeMeta = {
+    url: { label: "URL", group: "Web" },
+    domain: { label: "Domain", group: "Infrastructure" },
+    ipv4: { label: "IPv4", group: "Network" },
+    email: { label: "Email", group: "Identity" },
+    md5: { label: "MD5", group: "File" },
+    sha1: { label: "SHA-1", group: "File" },
+    sha256: { label: "SHA-256", group: "File" }
+  };
+
+  function track(name, parameters) {
+    if (!window.measurementConsentGranted || typeof window.gtag !== "function") return;
+    window.gtag("event", name, parameters || {});
+  }
+
+  function refang(value) {
+    return value
+      .replace(/\bhxxps\b/gi, "https")
+      .replace(/\bhxxp\b/gi, "http")
+      .replace(/\[(?:\.|dot)\]|\((?:\.|dot)\)|\{(?:\.|dot)\}/gi, ".")
+      .replace(/\[:\]/g, ":")
+      .replace(/\[\/\]/g, "/")
+      .replace(/\s+dot\s+/gi, ".");
+  }
+
+  function defang(value, type) {
+    var result = value;
+    if (type === "url") {
+      result = result.replace(/^https/gi, "hxxps").replace(/^http/gi, "hxxp");
+      result = result.replace("://", "[:]//");
+    }
+    if (type === "url" || type === "domain" || type === "ipv4" || type === "email") {
+      result = result.replace(/\./g, "[.]");
+    }
+    return result;
+  }
+
+  function overlaps(start, end, ranges) {
+    return ranges.some(function (range) {
+      return start < range.end && end > range.start;
+    });
+  }
+
+  function validIpv4(value) {
+    var parts = value.split(".");
+    return parts.length === 4 && parts.every(function (part) {
+      return /^\d{1,3}$/.test(part) && Number(part) <= 255;
+    });
+  }
+
+  function normalizeUrl(value) {
+    try {
+      var parsed = new URL(value);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+      parsed.hostname = parsed.hostname.toLowerCase();
+      return parsed.toString();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function hashType(value) {
+    if (value.length === 32) return "md5";
+    if (value.length === 40) return "sha1";
+    return "sha256";
+  }
+
+  function addMatches(text, regex, type, ranges, found, validator, normalizer) {
+    var match;
+    regex.lastIndex = 0;
+    while ((match = regex.exec(text)) !== null) {
+      var raw = match[0].replace(/[),.;!?]+$/, "");
+      var start = match.index;
+      var end = start + raw.length;
+      if (!raw || overlaps(start, end, ranges) || (validator && !validator(raw))) continue;
+      var value = normalizer ? normalizer(raw) : raw;
+      if (!value) continue;
+      found.push({ type: typeof type === "function" ? type(value) : type, value: value });
+      ranges.push({ start: start, end: end });
+    }
+  }
+
+  function extract(rawText) {
+    var text = refang(rawText);
+    var found = [];
+    var ranges = [];
+
+    addMatches(text, /\bhttps?:\/\/[^\s<>"'\x60]+/gi, "url", ranges, found, null, normalizeUrl);
+    addMatches(text, /\b(?:[a-f0-9]{64}|[a-f0-9]{40}|[a-f0-9]{32})\b/gi, hashType, ranges, found, null, function (value) { return value.toLowerCase(); });
+    addMatches(text, /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,63}\b/gi, "email", ranges, found, null, function (value) { return value.toLowerCase(); });
+    addMatches(text, /\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "ipv4", ranges, found, validIpv4);
+    addMatches(text, /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{2,63}|xn--[a-z0-9-]{2,59})\b/gi, "domain", ranges, found, null, function (value) { return value.toLowerCase(); });
+
+    var seen = new Set();
+    return found.filter(function (indicator) {
+      var key = indicator.type + ":" + indicator.value.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  function shownValue(indicator) {
+    return displayMode === "defanged" ? defang(indicator.value, indicator.type) : indicator.value;
+  }
+
+  function lookupLinks(indicator) {
+    var value = indicator.value;
+    var links = [{ label: "VirusTotal", url: "https://www.virustotal.com/gui/search/" + encodeURIComponent(value) }];
+    if (indicator.type === "ipv4") {
+      links.push({ label: "AbuseIPDB", url: "https://www.abuseipdb.com/check/" + encodeURIComponent(value) });
+    } else if (indicator.type === "domain") {
+      links.push({ label: "urlscan.io", url: "https://urlscan.io/search/#" + encodeURIComponent("domain:" + value) });
+    } else if (indicator.type === "url") {
+      links.push({ label: "urlscan.io", url: "https://urlscan.io/search/#" + encodeURIComponent('page.url:"' + value + '"') });
+    }
+    return links;
+  }
+
+  function renderSummary() {
+    var counts = indicators.reduce(function (result, indicator) {
+      result[indicator.type] = (result[indicator.type] || 0) + 1;
+      return result;
+    }, {});
+    summary.replaceChildren();
+
+    Object.keys(typeMeta).forEach(function (type) {
+      if (!counts[type]) return;
+      var item = document.createElement("div");
+      var count = document.createElement("strong");
+      var label = document.createElement("span");
+      item.className = "ioc-summary-item ioc-type-" + type;
+      count.textContent = counts[type];
+      label.textContent = typeMeta[type].label;
+      item.append(count, label);
+      summary.appendChild(item);
+    });
+  }
+
+  function renderList() {
+    list.replaceChildren();
+    indicators.forEach(function (indicator, index) {
+      var item = document.createElement("li");
+      var heading = document.createElement("div");
+      var type = document.createElement("span");
+      var group = document.createElement("span");
+      var value = document.createElement("code");
+      var actions = document.createElement("div");
+      var copy = document.createElement("button");
+
+      item.className = "ioc-item";
+      item.style.setProperty("--ioc-index", index);
+      heading.className = "ioc-item-heading";
+      type.className = "ioc-type ioc-type-" + indicator.type;
+      type.textContent = typeMeta[indicator.type].label;
+      group.textContent = typeMeta[indicator.type].group;
+      value.textContent = shownValue(indicator);
+      value.title = shownValue(indicator);
+      actions.className = "ioc-item-actions";
+      copy.type = "button";
+      copy.textContent = "Copy";
+      copy.addEventListener("click", function () {
+        copyText(shownValue(indicator), copy, "Copied");
+        track("ioc_copy_one", { indicator_type: indicator.type });
+      });
+
+      lookupLinks(indicator).forEach(function (lookup) {
+        var link = document.createElement("a");
+        link.href = lookup.url;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.textContent = lookup.label;
+        link.setAttribute("aria-label", "Investigate this " + typeMeta[indicator.type].label + " with " + lookup.label + " (opens in a new tab)");
+        link.addEventListener("click", function () {
+          track("ioc_lookup_open", { indicator_type: indicator.type, provider: lookup.label });
+        });
+        actions.appendChild(link);
+      });
+
+      actions.prepend(copy);
+      heading.append(type, group);
+      item.append(heading, value, actions);
+      list.appendChild(item);
+    });
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function render() {
+    var hasResults = indicators.length > 0;
+    emptyState.hidden = hasResults;
+    output.hidden = !hasResults;
+    modeFieldset.disabled = !hasResults;
+    if (!hasResults) return;
+    renderSummary();
+    renderList();
+    setStatus(indicators.length + (indicators.length === 1 ? " unique indicator" : " unique indicators") + " found.");
+  }
+
+  function copyText(text, button, successLabel) {
+    var originalLabel = button.textContent;
+    function showSuccess() {
+      button.textContent = successLabel;
+      window.setTimeout(function () { button.textContent = originalLabel; }, 1400);
+    }
+
+    function fallbackCopy() {
+      var helper = document.createElement("textarea");
+      helper.value = text;
+      helper.setAttribute("readonly", "");
+      helper.style.position = "fixed";
+      helper.style.opacity = "0";
+      document.body.appendChild(helper);
+      helper.select();
+      var copied = document.execCommand("copy");
+      helper.remove();
+      if (copied) showSuccess();
+      else setStatus("Copy was blocked by the browser. Select the text and copy it manually.");
+    }
+
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      fallbackCopy();
+      return;
+    }
+
+    navigator.clipboard.writeText(text).then(showSuccess).catch(function () {
+      fallbackCopy();
+    }).catch(function () {
+      setStatus("Copy was blocked by the browser. Select the text and copy it manually.");
+    });
+  }
+
+  function csvCell(value) {
+    var safe = /^[=+\-@]/.test(value) ? "'" + value : value;
+    return '"' + safe.replace(/"/g, '""') + '"';
+  }
+
+  function exportCsv() {
+    var rows = [["type", "indicator", "defanged"]];
+    indicators.forEach(function (indicator) {
+      rows.push([typeMeta[indicator.type].label, indicator.value, defang(indicator.value, indicator.type)]);
+    });
+    var csv = rows.map(function (row) { return row.map(csvCell).join(","); }).join("\r\n");
+    var blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement("a");
+    link.href = url;
+    link.download = "ioc-workbench-" + new Date().toISOString().slice(0, 10) + ".csv";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    setStatus("CSV export created for " + indicators.length + " indicators.");
+    track("ioc_export", { indicator_count: indicators.length });
+  }
+
+  analyzeButton.addEventListener("click", function () {
+    indicators = extract(input.value);
+    render();
+    if (!indicators.length) {
+      emptyState.querySelector("h3").textContent = input.value.trim() ? "No supported indicators found" : "Add indicators to begin";
+      emptyState.querySelector("p").textContent = input.value.trim() ? "Check the formatting or try the safe sample." : "Paste alert text or load the safe sample above.";
+    }
+    track("ioc_analyze", { indicator_count: indicators.length });
+  });
+
+  clearButton.addEventListener("click", function () {
+    input.value = "";
+    indicators = [];
+    render();
+    emptyState.querySelector("h3").textContent = "Ready for signal";
+    emptyState.querySelector("p").textContent = "Your classified indicators will appear here.";
+    input.focus();
+  });
+
+  sampleButton.addEventListener("click", function () {
+    input.value = [
+      "Alert artifacts:",
+      "hxxps://login-example[.]test/update?id=42",
+      "203[.]0[.]113[.]24",
+      "notify@example[.]test",
+      "44d88612fea8a8f36de82e1278abb02f",
+      "44d88612fea8a8f36de82e1278abb02f"
+    ].join("\n");
+    input.focus();
+  });
+
+  modeFieldset.addEventListener("change", function (event) {
+    if (event.target.name !== "ioc-mode") return;
+    displayMode = event.target.value;
+    renderList();
+    setStatus("Indicators are now shown " + displayMode + ".");
+  });
+
+  copyButton.addEventListener("click", function () {
+    copyText(indicators.map(shownValue).join("\n"), copyButton, "Copied all");
+    track("ioc_copy_all", { indicator_count: indicators.length });
+  });
+
+  exportButton.addEventListener("click", exportCsv);
+
+  input.addEventListener("keydown", function (event) {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") analyzeButton.click();
+  });
+})();

--- a/ioc-workbench.md
+++ b/ioc-workbench.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: IOC Workbench
+description: A fast, privacy-first browser tool for extracting, classifying, deduplicating, defanging, and exporting cybersecurity indicators of compromise.
+permalink: /ioc-workbench/
+---
+
+<article class="ioc-workbench" data-ioc-workbench>
+  <header class="ioc-hero">
+    <div class="ioc-hero-copy">
+      <p class="ioc-eyebrow"><span aria-hidden="true"></span> Browser-based SOC utility</p>
+      <h1>Turn raw indicators into investigation-ready intelligence.</h1>
+      <p>Extract, classify, deduplicate, defang, and export IP addresses, domains, URLs, email addresses, and hashes in seconds.</p>
+      <ul class="ioc-trust-list" aria-label="Privacy and usability features">
+        <li>Runs locally</li>
+        <li>No account</li>
+        <li>No IOC telemetry</li>
+      </ul>
+    </div>
+    <div class="ioc-signal" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span>
+    </div>
+  </header>
+
+  <section class="ioc-panel" aria-labelledby="ioc-input-title">
+    <div class="ioc-panel-heading">
+      <div>
+        <p class="ioc-step">01 / INGEST</p>
+        <h2 id="ioc-input-title">Paste suspicious indicators</h2>
+      </div>
+      <button class="ioc-text-button" type="button" data-ioc-sample>Load safe sample</button>
+    </div>
+
+    <label class="ioc-label" for="ioc-input">Raw IOC text</label>
+    <textarea id="ioc-input" data-ioc-input rows="9" spellcheck="false" autocomplete="off" placeholder="Paste an incident note, alert, or list of indicators…"></textarea>
+    <p class="ioc-input-hint">Supports plain and defanged indicators such as <code>hxxps://example[.]com/path</code>. Press <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Enter</kbd> to analyze. Nothing is uploaded.</p>
+
+    <div class="ioc-actions">
+      <button class="ioc-primary-button" type="button" data-ioc-analyze>
+        <span aria-hidden="true">⌁</span> Analyze indicators
+      </button>
+      <button class="ioc-secondary-button" type="button" data-ioc-clear>Clear</button>
+    </div>
+  </section>
+
+  <section class="ioc-results" aria-labelledby="ioc-results-title">
+    <div class="ioc-panel-heading">
+      <div>
+        <p class="ioc-step">02 / TRIAGE</p>
+        <h2 id="ioc-results-title">Normalized results</h2>
+      </div>
+      <fieldset class="ioc-mode" data-ioc-mode disabled>
+        <legend class="screen-reader-text">Indicator display format</legend>
+        <label><input type="radio" name="ioc-mode" value="defanged" checked> Defanged</label>
+        <label><input type="radio" name="ioc-mode" value="refanged"> Refanged</label>
+      </fieldset>
+    </div>
+
+    <div class="ioc-empty" data-ioc-empty>
+      <span aria-hidden="true">◎</span>
+      <h3>Ready for signal</h3>
+      <p>Your classified indicators will appear here.</p>
+    </div>
+
+    <div data-ioc-output hidden>
+      <div class="ioc-summary" data-ioc-summary aria-label="Indicator summary"></div>
+      <div class="ioc-result-toolbar">
+        <p data-ioc-status role="status" aria-live="polite"></p>
+        <div>
+          <button class="ioc-secondary-button" type="button" data-ioc-copy>Copy all</button>
+          <button class="ioc-secondary-button" type="button" data-ioc-export>Export CSV</button>
+        </div>
+      </div>
+      <ol class="ioc-list" data-ioc-list></ol>
+      <p class="ioc-lookup-note"><strong>Investigation links are optional.</strong> Opening one shares that single indicator with the named external provider.</p>
+    </div>
+  </section>
+
+  <aside class="ioc-guidance" aria-labelledby="ioc-guidance-title">
+    <p class="ioc-step">FIELD NOTE</p>
+    <h2 id="ioc-guidance-title">Treat enrichment as evidence, not a verdict.</h2>
+    <p>Correlate reputation results with endpoint, identity, network, and timeline evidence. A clean lookup does not prove an indicator is safe, and a detection does not always prove malicious intent.</p>
+  </aside>
+</article>
+
+<script src="{{ '/assets/js/ioc-workbench.js' | relative_url }}" defer></script>


### PR DESCRIPTION
## Summary

Adds an interactive IOC Workbench at `/ioc-workbench/` and surfaces it in the site menu, footer, and a prominent homepage feature card.

Visitors can:

- extract URLs, domains, IPv4 addresses, email addresses, MD5, SHA-1, and SHA-256 indicators from mixed text
- normalize previously defanged indicators
- deduplicate results and reject invalid IPv4 values
- switch safely between defanged and refanged output
- copy one or all indicators with a compatibility fallback
- export formula-safe CSV
- deliberately open per-indicator VirusTotal, AbuseIPDB, or urlscan.io lookups

The tool runs entirely in the browser. Indicator values are never sent to site analytics; only aggregate interaction counts are eligible for consent-gated GA4 measurement. External providers receive an indicator only when the visitor explicitly opens a named investigation link.

## Experience

- responsive SOC-style interface with lightweight, reduced-motion-aware animations
- accessible labels, landmarks, live status updates, keyboard shortcut, focus states, and 44–46px controls
- homepage discovery card and navigation entry
- safe sample uses reserved documentation domains and IP ranges

## Validation

- JavaScript syntax check
- `git diff --check`
- production-equivalent Ruby 3.4 Jekyll build with strict front matter
- desktop and 390px mobile browser tests
- verified sample extraction, deduplication, invalid-IP rejection, all supported hash types, defang/refang, copy, CSV export, keyboard shortcut, lookup URLs, homepage navigation, and zero horizontal overflow