### PR TITLE
Improve IOC Workbench filtering, extraction, and privacy

### DIFF
--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -1,3 +1,3 @@
 {% if site.google_analytics %}
-<script src="{{ '/assets/js/privacy.js' | relative_url }}?v={{ site.time | date: '%s' }}" data-measurement-id="{{ site.google_analytics | escape }}"></script>
+<script src="{{ '/assets/js/privacy.js' | relative_url }}?v={{ site.time | date: '%s' }}" data-measurement-id="{{ site.google_analytics | escape }}"{% if page.measurement_disabled %} data-measurement-disabled="true"{% endif %}></script>
 {% endif %}

--- a/_sass/_ioc-workbench.scss
+++ b/_sass/_ioc-workbench.scss
@@ -24,10 +24,39 @@
 
   button,
   textarea,
-  input {
+  input,
+  select {
     font: inherit;
   }
+
+  [hidden] { display: none !important; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
 }
+
+.ioc-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem(16px);
+  margin-bottom: rem(20px);
+
+  label { flex: 1 1 rem(180px); min-width: 0; font-weight: 700; }
+  input, select {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: rem(8px);
+    min-height: rem(46px);
+    padding: rem(10px);
+    border: 1px solid #bac4cb;
+    border-radius: rem(7px);
+    background: #fff;
+    color: #111820;
+  }
+  :focus-visible { outline: 3px solid #a6000e; outline-offset: 2px; }
+}
+
+[data-ioc-feedback] { line-height: 1.5; }
+[data-ioc-more] { margin-top: rem(18px); }
 
 .ioc-hero {
   position: relative;
@@ -367,13 +396,12 @@
   animation-delay: calc(var(--ioc-index) * 35ms);
 
   code {
-    overflow: hidden;
+    overflow-wrap: anywhere;
     padding: 0;
     background: transparent;
     color: #26343e;
     font-size: rem(14px);
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
   }
 }
 

--- a/assets/js/ioc-workbench.js
+++ b/assets/js/ioc-workbench.js
@@ -16,6 +16,11 @@
   var modeFieldset = root.querySelector("[data-ioc-mode]");
   var copyButton = root.querySelector("[data-ioc-copy]");
   var exportButton = root.querySelector("[data-ioc-export]");
+  var feedback = root.querySelector("[data-ioc-feedback]");
+  var typeFilter = root.querySelector("[data-ioc-filter]");
+  var searchInput = root.querySelector("[data-ioc-search]");
+  var moreButton = root.querySelector("[data-ioc-more]");
+  var visibleLimit = 100;
   var indicators = [];
   var displayMode = "defanged";
 
@@ -41,6 +46,7 @@
       .replace(/\[(?:\.|dot)\]|\((?:\.|dot)\)|\{(?:\.|dot)\}/gi, ".")
       .replace(/\[:\]/g, ":")
       .replace(/\[\/\]/g, "/")
+      .replace(/\[@\]|\(at\)/gi, "@")
       .replace(/\s+dot\s+/gi, ".");
   }
 
@@ -90,9 +96,22 @@
     var match;
     regex.lastIndex = 0;
     while ((match = regex.exec(text)) !== null) {
-      var raw = match[0].replace(/[),.;!?]+$/, "");
+      var raw = match[0];
+      if (type === "url") {
+        // Remove unmatched prose wrappers, but preserve balanced URL parentheses
+        // and meaningful query/path punctuation.
+        while (/[)\]}]$/.test(raw)) {
+          var close = raw.slice(-1);
+          var open = { ")": "(", "]": "[", "}": "{" }[close];
+          if (raw.split(close).length <= raw.split(open).length) break;
+          raw = raw.slice(0, -1);
+        }
+      }
       var start = match.index;
       var end = start + raw.length;
+      if (type !== "url" && (/[a-z0-9_@.%-]/i.test(text.charAt(start - 1)) ||
+          /[a-z0-9_@%-]/i.test(text.charAt(end)))) continue;
+      if (type !== "url" && text.charAt(end) === "." && /[a-z0-9.]/i.test(text.charAt(end + 1))) continue;
       if (!raw || overlaps(start, end, ranges) || (validator && !validator(raw))) continue;
       var value = normalizer ? normalizer(raw) : raw;
       if (!value) continue;
@@ -108,16 +127,40 @@
 
     addMatches(text, /\bhttps?:\/\/[^\s<>"'\x60]+/gi, "url", ranges, found, null, normalizeUrl);
     addMatches(text, /\b(?:[a-f0-9]{64}|[a-f0-9]{40}|[a-f0-9]{32})\b/gi, hashType, ranges, found, null, function (value) { return value.toLowerCase(); });
-    addMatches(text, /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,63}\b/gi, "email", ranges, found, null, function (value) { return value.toLowerCase(); });
+    addMatches(text, /(?<![a-z0-9._%+\-])[a-z0-9._%+\-]+@[a-z0-9.-]+\.[a-z]{2,63}\b/gi, "email", ranges, found, function (value) {
+      var parts = value.split("@");
+      return !/^\.|\.$|\.\./.test(parts[0]) && validDomain(parts[1]);
+    }, function (value) {
+      var parts = value.split("@");
+      return parts[0] + "@" + parts[1].toLowerCase();
+    });
     addMatches(text, /\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "ipv4", ranges, found, validIpv4);
-    addMatches(text, /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{2,63}|xn--[a-z0-9-]{2,59})\b/gi, "domain", ranges, found, null, function (value) { return value.toLowerCase(); });
+    addMatches(text, /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:xn--[a-z0-9-]{2,59}|[a-z]{2,63})\b/gi, "domain", ranges, found, validDomain, function (value) { return value.toLowerCase(); });
 
-    var seen = new Set();
+    var seen = new Map();
     return found.filter(function (indicator) {
-      var key = indicator.type + ":" + indicator.value.toLowerCase();
-      if (seen.has(key)) return false;
-      seen.add(key);
+      var key = indicator.type + ":" + indicator.value;
+      if (seen.has(key)) {
+        seen.get(key).occurrences += 1;
+        return false;
+      }
+      indicator.occurrences = 1;
+      seen.set(key, indicator);
       return true;
+    });
+  }
+
+  function validDomain(value) {
+    return value.length <= 253 && value.split(".").every(function (label) {
+      return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(label);
+    });
+  }
+
+  function matchingIndicators() {
+    var query = refang(searchInput.value.trim()).toLowerCase();
+    return indicators.filter(function (indicator) {
+      return (typeFilter.value === "all" || indicator.type === typeFilter.value) &&
+        indicator.value.toLowerCase().includes(query);
     });
   }
 
@@ -160,7 +203,8 @@
 
   function renderList() {
     list.replaceChildren();
-    indicators.forEach(function (indicator, index) {
+    var matching = matchingIndicators();
+    matching.slice(0, visibleLimit).forEach(function (indicator, index) {
       var item = document.createElement("li");
       var heading = document.createElement("div");
       var type = document.createElement("span");
@@ -170,11 +214,11 @@
       var copy = document.createElement("button");
 
       item.className = "ioc-item";
-      item.style.setProperty("--ioc-index", index);
+      item.style.setProperty("--ioc-index", Math.min(index, 8));
       heading.className = "ioc-item-heading";
       type.className = "ioc-type ioc-type-" + indicator.type;
       type.textContent = typeMeta[indicator.type].label;
-      group.textContent = typeMeta[indicator.type].group;
+      group.textContent = typeMeta[indicator.type].group + " · " + indicator.occurrences + (indicator.occurrences === 1 ? " occurrence" : " occurrences");
       value.textContent = shownValue(indicator);
       value.title = shownValue(indicator);
       actions.className = "ioc-item-actions";
@@ -203,6 +247,10 @@
       item.append(heading, value, actions);
       list.appendChild(item);
     });
+    moreButton.hidden = matching.length <= visibleLimit;
+    copyButton.disabled = exportButton.disabled = matching.length === 0;
+    setStatus(matching.length + " of " + indicators.length + " unique indicators match. " +
+      (matching.length > visibleLimit ? "Showing " + visibleLimit + "; copy and export include all matches." : ""));
   }
 
   function setStatus(message) {
@@ -214,10 +262,13 @@
     emptyState.hidden = hasResults;
     output.hidden = !hasResults;
     modeFieldset.disabled = !hasResults;
-    if (!hasResults) return;
+    if (!hasResults) {
+      list.replaceChildren();
+      summary.replaceChildren();
+      return;
+    }
     renderSummary();
     renderList();
-    setStatus(indicators.length + (indicators.length === 1 ? " unique indicator" : " unique indicators") + " found.");
   }
 
   function copyText(text, button, successLabel) {
@@ -229,14 +280,20 @@
 
     function fallbackCopy() {
       var helper = document.createElement("textarea");
+      var previousFocus = document.activeElement;
       helper.value = text;
       helper.setAttribute("readonly", "");
       helper.style.position = "fixed";
       helper.style.opacity = "0";
       document.body.appendChild(helper);
       helper.select();
-      var copied = document.execCommand("copy");
-      helper.remove();
+      var copied = false;
+      try { copied = document.execCommand("copy"); }
+      catch (error) { copied = false; }
+      finally {
+        helper.remove();
+        if (previousFocus) previousFocus.focus();
+      }
       if (copied) showSuccess();
       else setStatus("Copy was blocked by the browser. Select the text and copy it manually.");
     }
@@ -259,9 +316,11 @@
   }
 
   function exportCsv() {
-    var rows = [["type", "indicator", "defanged"]];
-    indicators.forEach(function (indicator) {
-      rows.push([typeMeta[indicator.type].label, indicator.value, defang(indicator.value, indicator.type)]);
+    var matching = matchingIndicators();
+    if (!matching.length) return;
+    var rows = [["type", "indicator", "defanged", "occurrences"]];
+    matching.forEach(function (indicator) {
+      rows.push([typeMeta[indicator.type].label, indicator.value, defang(indicator.value, indicator.type), String(indicator.occurrences)]);
     });
     var csv = rows.map(function (row) { return row.map(csvCell).join(","); }).join("\r\n");
     var blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
@@ -272,14 +331,24 @@
     document.body.appendChild(link);
     link.click();
     link.remove();
-    URL.revokeObjectURL(url);
-    setStatus("CSV export created for " + indicators.length + " indicators.");
-    track("ioc_export", { indicator_count: indicators.length });
+    window.setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    setStatus("CSV export created for " + matching.length + " indicators.");
+    track("ioc_export", { indicator_count: matching.length });
   }
 
   analyzeButton.addEventListener("click", function () {
+    if (input.value.length > 100000) {
+      invalidateResults();
+      feedback.textContent = "This batch is too large. Split it into batches of 100,000 characters or fewer.";
+      return;
+    }
+    typeFilter.value = "all";
+    searchInput.value = "";
+    visibleLimit = 100;
     indicators = extract(input.value);
     render();
+    var total = indicators.reduce(function (sum, indicator) { return sum + indicator.occurrences; }, 0);
+    feedback.textContent = indicators.length + " unique indicators found; " + (total - indicators.length) + " duplicate occurrences combined.";
     if (!indicators.length) {
       emptyState.querySelector("h3").textContent = input.value.trim() ? "No supported indicators found" : "Add indicators to begin";
       emptyState.querySelector("p").textContent = input.value.trim() ? "Check the formatting or try the safe sample." : "Paste alert text or load the safe sample above.";
@@ -290,6 +359,7 @@
   clearButton.addEventListener("click", function () {
     input.value = "";
     indicators = [];
+    feedback.textContent = "Input and results cleared.";
     render();
     emptyState.querySelector("h3").textContent = "Ready for signal";
     emptyState.querySelector("p").textContent = "Your classified indicators will appear here.";
@@ -305,6 +375,7 @@
       "44d88612fea8a8f36de82e1278abb02f",
       "44d88612fea8a8f36de82e1278abb02f"
     ].join("\n");
+    invalidateResults();
     input.focus();
   });
 
@@ -316,11 +387,33 @@
   });
 
   copyButton.addEventListener("click", function () {
-    copyText(indicators.map(shownValue).join("\n"), copyButton, "Copied all");
-    track("ioc_copy_all", { indicator_count: indicators.length });
+    var matching = matchingIndicators();
+    if (!matching.length) return;
+    copyText(matching.map(shownValue).join("\n"), copyButton, "Copied");
+    track("ioc_copy_all", { indicator_count: matching.length });
   });
 
   exportButton.addEventListener("click", exportCsv);
+
+  function invalidateResults() {
+    indicators = [];
+    render();
+    feedback.textContent = "Input changed. Analyze again to refresh results.";
+    emptyState.querySelector("h3").textContent = "Ready to analyze";
+    emptyState.querySelector("p").textContent = "Analyze the current input to see matching indicators.";
+  }
+
+  Object.keys(typeMeta).forEach(function (type) {
+    var option = document.createElement("option");
+    option.value = type;
+    option.textContent = typeMeta[type].label;
+    typeFilter.appendChild(option);
+  });
+  input.addEventListener("input", invalidateResults);
+  [typeFilter, searchInput].forEach(function (control) {
+    control.addEventListener("input", function () { visibleLimit = 100; renderList(); });
+  });
+  moreButton.addEventListener("click", function () { visibleLimit += 100; renderList(); });
 
   input.addEventListener("keydown", function (event) {
     if ((event.metaKey || event.ctrlKey) && event.key === "Enter") analyzeButton.click();

--- a/assets/js/privacy.js
+++ b/assets/js/privacy.js
@@ -33,7 +33,7 @@
   });
 
   function loadMeasurementScripts() {
-    if (scriptsLoaded || !isProduction) return;
+    if (scriptsLoaded || !isProduction || bootstrapScript.dataset.measurementDisabled === "true") return;
     scriptsLoaded = true;
 
     window.gtag("js", new Date());

--- a/docs/tests/ioc-workbench.test.cjs
+++ b/docs/tests/ioc-workbench.test.cjs
@@ -1,0 +1,80 @@
+// Run with Node.js: node docs/tests/ioc-workbench.test.cjs
+// Exercise the real UI handlers with a minimal DOM, no network or dependencies.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+class Element {
+  constructor() { this.children = []; this.listeners = {}; this.value = ''; this.textContent = ''; this.style = { setProperty() {} }; this.hidden = false; }
+  querySelector(selector) { return this.nodes?.[selector]; }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  fire(name, event = {}) { this.listeners[name]?.(event); }
+  click() { this.fire('click'); }
+  append(...items) { this.children.push(...items); }
+  appendChild(item) { this.append(item); }
+  prepend(item) { this.children.unshift(item); }
+  replaceChildren() { this.children = []; }
+  setAttribute() {}
+  focus() {}
+  select() {}
+  remove() {}
+}
+const root = new Element(); root.nodes = {};
+const names = ['input', 'analyze', 'clear', 'sample', 'empty', 'output', 'summary', 'list', 'status', 'mode', 'copy', 'export', 'feedback', 'filter', 'search', 'more'];
+const el = Object.fromEntries(names.map(name => {
+  const node = new Element(); root.nodes['[data-ioc-' + name + ']'] = node; return [name, node];
+}));
+el.empty.nodes = { h3: new Element(), p: new Element() }; el.filter.value = 'all';
+let copied = ''; let exported;
+class TestURL extends URL {}
+TestURL.createObjectURL = blob => { exported = blob; return 'blob:test'; };
+TestURL.revokeObjectURL = () => {};
+const context = { document: { querySelector: () => root, createElement: () => new Element(), body: new Element(), execCommand: () => false }, window: { setTimeout() {} }, navigator: { clipboard: { writeText: text => { copied = text; return Promise.resolve(); } } }, URL: TestURL, Blob };
+vm.runInNewContext(fs.readFileSync(path.join(__dirname, '../../assets/js/ioc-workbench.js'), 'utf8'), context);
+function analyze(text) { el.input.value = text; el.analyze.click(); }
+function values() { return el.list.children.map(row => row.children[1].textContent); }
+async function run() {
+  const privacySource = fs.readFileSync(path.join(__dirname, '../../assets/js/privacy.js'), 'utf8');
+  for (const disabled of [true, false]) {
+    for (const choice of ['allow', 'reject']) {
+      const head = new Element();
+      const privacyWindow = { location: { hostname: 'harsim.ca', reload() {} }, localStorage: { getItem: () => choice, setItem() {} } };
+      const privacyDocument = { currentScript: { dataset: { measurementId: 'G-TEST', measurementDisabled: String(disabled) } }, head, cookie: '', createElement: () => new Element() };
+      vm.runInNewContext(privacySource, { window: privacyWindow, document: privacyDocument });
+      assert.equal(head.children.length, !disabled && choice === 'allow' ? 1 : 0);
+      privacyWindow.sitePrivacy.setChoice('allow');
+      assert.equal(head.children.length, disabled ? 0 : 1, 'Only enabled pages load measurement after consent');
+    }
+  }
+  analyze('https://EXAMPLE.test/A https://example.test/a https://example.test/A');
+  assert.equal(values().length, 2, 'URL path case must distinguish indicators');
+  assert.match(el.list.children[0].children[0].children[1].textContent, /2 occurrences/);
+  analyze('(https://example.test/wiki/Foo_(bar)) https://example.test/?');
+  assert.deepEqual(values(), ['hxxps[:]//example[.]test/wiki/Foo_(bar)', 'hxxps[:]//example[.]test/?']);
+  analyze('Admin[@]EXAMPLE[.]test admin@example.test 203[.]0[.]113[.]24');
+  assert.equal(values().length, 3, 'Preserve email local-part case');
+  analyze('999.2.3.4 1.2.3.4.5 1234.2.3.4 bad..example.test -bad.test 203.0.113.1');
+  assert.deepEqual(values(), ['203[.]0[.]113[.]1'], 'Do not extract valid fragments from malformed indicators');
+  analyze('example.test EXAMPLE.TEST 203.0.113.1');
+  el.filter.value = 'domain'; el.filter.fire('input');
+  assert.equal(values().length, 1); el.copy.click();
+  assert.equal(copied, 'example[.]test');
+  el.export.click();
+  const csv = await exported.text();
+  assert.match(csv, /"Domain","example.test","example\[\.\]test","2"/);
+  assert.ok(!csv.includes('203.0.113.1'), 'Export only matches');
+  el.search.value = 'nomatch'; el.search.fire('input');
+  assert.equal(values().length, 0); assert.equal(el.copy.disabled, true);
+  el.input.fire('input'); assert.equal(el.output.hidden, true); assert.equal(values().length, 0);
+  analyze('example.test'); el.sample.click(); assert.equal(el.output.hidden, true);
+  analyze('x'.repeat(100001)); assert.match(el.feedback.textContent, /too large/);
+  analyze('x'.repeat(100000)); assert.equal(values().length, 0, 'Large non-indicator tokens complete without partial matches');
+  analyze(Array.from({length: 205}, (_, i) => 'host' + i + '.test').join('\n'));
+  assert.equal(values().length, 100); assert.equal(el.more.hidden, false);
+  el.copy.click(); assert.equal(copied.split('\n').length, 205, 'Copy includes undisplayed matches');
+  el.more.click(); assert.equal(values().length, 200);
+  el.more.click(); assert.equal(values().length, 205); assert.equal(el.more.hidden, true);
+  el.clear.click(); assert.equal(el.input.value, ''); assert.equal(values().length, 0);
+  console.log('IOC extraction, filtering, copy/export, stale results, input limit, pagination, and measurement privacy checks passed.');
+}
+run().catch(error => { console.error(error); process.exitCode = 1; });

--- a/ioc-workbench.md
+++ b/ioc-workbench.md
@@ -3,6 +3,7 @@ layout: default
 title: IOC Workbench
 description: A fast, privacy-first browser tool for extracting, classifying, deduplicating, defanging, and exporting cybersecurity indicators of compromise.
 permalink: /ioc-workbench/
+measurement_disabled: true
 ---
 
 <article class="ioc-workbench" data-ioc-workbench>
@@ -33,7 +34,8 @@ permalink: /ioc-workbench/
 
     <label class="ioc-label" for="ioc-input">Raw IOC text</label>
     <textarea id="ioc-input" data-ioc-input rows="9" spellcheck="false" autocomplete="off" placeholder="Paste an incident note, alert, or list of indicators…"></textarea>
-    <p class="ioc-input-hint">Supports plain and defanged indicators such as <code>hxxps://example[.]com/path</code>. Press <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Enter</kbd> to analyze. Nothing is uploaded.</p>
+    <p class="ioc-input-hint">Supports IPv4, domains, HTTP(S) URLs, email addresses, and MD5/SHA-1/SHA-256 hashes, including <code>hxxps://example[.]com/path</code>. Up to 100,000 characters per batch. Press <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>Enter</kbd> to analyze. Nothing is uploaded.</p>
+    <p data-ioc-feedback role="status" aria-live="polite"></p>
 
     <div class="ioc-actions">
       <button class="ioc-primary-button" type="button" data-ioc-analyze>
@@ -64,14 +66,20 @@ permalink: /ioc-workbench/
 
     <div data-ioc-output hidden>
       <div class="ioc-summary" data-ioc-summary aria-label="Indicator summary"></div>
+      <div class="ioc-filters">
+        <label>Indicator type <select data-ioc-filter><option value="all">All types</option></select></label>
+        <label>Find an indicator <input data-ioc-search type="search" placeholder="Search values…" autocomplete="off" spellcheck="false"></label>
+      </div>
       <div class="ioc-result-toolbar">
         <p data-ioc-status role="status" aria-live="polite"></p>
         <div>
-          <button class="ioc-secondary-button" type="button" data-ioc-copy>Copy all</button>
-          <button class="ioc-secondary-button" type="button" data-ioc-export>Export CSV</button>
+          <button class="ioc-secondary-button" type="button" data-ioc-copy>Copy matching</button>
+          <button class="ioc-secondary-button" type="button" data-ioc-export>Export matching CSV</button>
         </div>
       </div>
       <ol class="ioc-list" data-ioc-list></ol>
+      <button class="ioc-secondary-button" type="button" data-ioc-more hidden>Show more</button>
+      <p class="ioc-input-hint">Copy uses the selected display format. CSV includes normalized and defanged values plus occurrence counts. URL paths and email local-part capitalization are preserved. Review extracted candidates before using them; a URL or email is kept whole, without also listing its embedded domain. Trailing URL punctuation can be part of the address, so check values pasted from prose.</p>
       <p class="ioc-lookup-note"><strong>Investigation links are optional.</strong> Opening one shares that single indicator with the named external provider.</p>
     </div>
   </section>


### PR DESCRIPTION
IOC Workbench now lets analysts filter by indicator type, search values, and copy or export every matching result. Duplicate occurrence counts and batches of 100 visible rows make longer notes easier to review.

Fixes preserve case-sensitive URL paths and email local parts, retain meaningful URL punctuation, reject partial matches inside malformed indicators, and clear stale results when input changes. Long values wrap, animation delays are capped, clipboard fallback cleans up after errors, and CSV download URLs are revoked after a delay. Input is limited to 100,000 characters with an explicit message; the email matcher avoids repeatedly scanning long non-email tokens.

Google measurement is disabled on this page so automatic outbound-link tracking cannot collect indicators through lookup URLs. Consent controls and analytics on other pages retain their existing behavior.

Validation: containerized Jekyll build passed with existing Sass deprecation warnings; dependency-free regression tests cover extraction, occurrence counts, filters, copy/export, stale results, input limits, pagination, and measurement consent behavior. Browser checks verified type filtering, refanged values, stale-result clearing, and mobile layout at 390px without horizontal overflow.