### PR TITLE
Fix IOC Workbench initialization on older Safari

### DIFF
--- a/assets/js/ioc-workbench.js
+++ b/assets/js/ioc-workbench.js
@@ -96,7 +96,10 @@
     var match;
     regex.lastIndex = 0;
     while ((match = regex.exec(text)) !== null) {
-      var raw = match[0];
+      // The email pattern consumes its boundary instead of using lookbehind.
+      // Only capture group 1 is the indicator; exclude the prefix from offsets.
+      var raw = type === "email" ? match[1] : match[0];
+      var start = match.index + match[0].length - raw.length;
       if (type === "url") {
         // Remove unmatched prose wrappers, but preserve balanced URL parentheses
         // and meaningful query/path punctuation.
@@ -107,7 +110,6 @@
           raw = raw.slice(0, -1);
         }
       }
-      var start = match.index;
       var end = start + raw.length;
       if (type !== "url" && (/[a-z0-9_@.%-]/i.test(text.charAt(start - 1)) ||
           /[a-z0-9_@%-]/i.test(text.charAt(end)))) continue;
@@ -127,7 +129,7 @@
 
     addMatches(text, /\bhttps?:\/\/[^\s<>"'\x60]+/gi, "url", ranges, found, null, normalizeUrl);
     addMatches(text, /\b(?:[a-f0-9]{64}|[a-f0-9]{40}|[a-f0-9]{32})\b/gi, hashType, ranges, found, null, function (value) { return value.toLowerCase(); });
-    addMatches(text, /(?<![a-z0-9._%+\-])[a-z0-9._%+\-]+@[a-z0-9.-]+\.[a-z]{2,63}\b/gi, "email", ranges, found, function (value) {
+    addMatches(text, /(?:^|[^a-z0-9._%+\-])([a-z0-9._%+\-]+@[a-z0-9.-]+\.[a-z]{2,63}\b)/gi, "email", ranges, found, function (value) {
       var parts = value.split("@");
       return !/^\.|\.$|\.\./.test(parts[0]) && validDomain(parts[1]);
     }, function (value) {

--- a/docs/tests/ioc-workbench.test.cjs
+++ b/docs/tests/ioc-workbench.test.cjs
@@ -30,7 +30,9 @@ class TestURL extends URL {}
 TestURL.createObjectURL = blob => { exported = blob; return 'blob:test'; };
 TestURL.revokeObjectURL = () => {};
 const context = { document: { querySelector: () => root, createElement: () => new Element(), body: new Element(), execCommand: () => false }, window: { setTimeout() {} }, navigator: { clipboard: { writeText: text => { copied = text; return Promise.resolve(); } } }, URL: TestURL, Blob };
-vm.runInNewContext(fs.readFileSync(path.join(__dirname, '../../assets/js/ioc-workbench.js'), 'utf8'), context);
+const workbenchSource = fs.readFileSync(path.join(__dirname, '../../assets/js/ioc-workbench.js'), 'utf8');
+assert.ok(!workbenchSource.includes('(?<!') && !workbenchSource.includes('(?<='), 'Workbench must avoid regex lookbehind for older Safari');
+vm.runInNewContext(workbenchSource, context);
 function analyze(text) { el.input.value = text; el.analyze.click(); }
 function values() { return el.list.children.map(row => row.children[1].textContent); }
 async function run() {
@@ -53,6 +55,12 @@ async function run() {
   assert.deepEqual(values(), ['hxxps[:]//example[.]test/wiki/Foo_(bar)', 'hxxps[:]//example[.]test/?']);
   analyze('Admin[@]EXAMPLE[.]test admin@example.test 203[.]0[.]113[.]24');
   assert.equal(values().length, 3, 'Preserve email local-part case');
+  analyze('+tag@example.test,second@example.test\n(user+tag@example.test)');
+  assert.deepEqual(values(), ['+tag@example[.]test', 'second@example[.]test', 'user+tag@example[.]test'], 'Email boundary prefixes are excluded from values');
+  analyze('.bad@example.test bad..name@example.test bad@example..test @nested@example.test');
+  assert.deepEqual(values(), [], 'Do not recover email fragments from malformed tokens');
+  analyze('https://example.test/user@example.test person@example.test');
+  assert.deepEqual(values(), ['hxxps[:]//example[.]test/user@example[.]test', 'person@example[.]test'], 'Email offsets still respect URL overlap');
   analyze('999.2.3.4 1.2.3.4.5 1234.2.3.4 bad..example.test -bad.test 203.0.113.1');
   assert.deepEqual(values(), ['203[.]0[.]113[.]1'], 'Do not extract valid fragments from malformed indicators');
   analyze('example.test EXAMPLE.TEST 203.0.113.1');


### PR DESCRIPTION
The email regex used lookbehind, which prevents the entire workbench script from parsing on Safari versions without that feature. It now consumes a boundary prefix and captures only the email, adjusting offsets before existing boundary and overlap validation. This preserves efficient scanning of long non-email tokens.

Regression checks pass for adjacent and plus-prefixed emails, malformed boundaries, emails embedded in URLs, and 100,000-character input, alongside the existing filter/export/privacy tests. Added a guard against reintroducing lookbehind. Historical Safari was not available for direct testing.